### PR TITLE
github/workflows: fix the syntax error in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,6 @@
 name: build
 
-on:
-  # Trigger the workflow on push or pull request,
-  # but only for the master branch
-  push:
-    branches:
-      - *
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
 
 env:
   GOPATH: /tmp/go


### PR DESCRIPTION
Fixes the error in https://github.com/golang/vscode-go/actions/runs/53803644

And triggers the workflow for all push/prs.