### PR TITLE
test/integration: use default GOPATH when the env var is not set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,6 @@ name: build
 
 on: [push, pull_request]
 
-env:
-  GOPATH: /tmp/go
-  # Because some tests require explicit setting of GOPATH. TODO: FIX THEM.
-   
 jobs:
   build:
     name: ${{ matrix.os }} ${{ matrix.version }}

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -71,7 +71,7 @@ suite('Go Extension Tests', function() {
 	const generateTestsSourcePath = path.join(repoPath, 'generatetests');
 	const generateFunctionTestSourcePath = path.join(repoPath, 'generatefunctiontest');
 	const generatePackageTestSourcePath = path.join(repoPath, 'generatePackagetest');
-	const toolsGopath = getToolsGopath() || getCurrentGoPath();
+	const toolsGopath = getToolsGopath() || gopath;
 
 	const dummyCancellationSource = new vscode.CancellationTokenSource();
 

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -36,9 +36,29 @@ import {
 	isVendorSupported
 } from '../../src/util';
 
+function queryDefaultGopathSync(): string {
+	const goExecutable = getBinPath('go');
+	if (!goExecutable) {
+		console.warn(`Failed to run "go env GOPATH" to find mod file as the "go" binary cannot be found`);
+		return null;
+	}
+	let gopath: string;
+	try {
+		const stdout = cp.execFileSync(goExecutable, ['env', 'GOPATH']);
+		console.log(`Got go env GOPATH result: ${stdout}`);
+		gopath = stdout.toString().trim();
+	} catch (err) {
+		console.warn(`Error when running go env GOPATH: ${err}`);
+	}
+	return gopath;
+}
+
 suite('Go Extension Tests', function() {
 	this.timeout(10000);
-	const gopath = getCurrentGoPath();
+	let gopath = getCurrentGoPath();
+	if (!gopath) {
+			gopath = queryDefaultGopathSync();
+	}
 	if (!gopath) {
 		assert.ok(gopath, 'Cannot run tests if GOPATH is not set as environment variable');
 		return;

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -36,7 +36,7 @@ import {
 	isVendorSupported
 } from '../../src/util';
 
-function queryDefaultGopathSync(): string {
+function queryDefaultGopathSync(): string | null {
 	const goExecutable = getBinPath('go');
 	if (!goExecutable) {
 		console.warn(`Failed to run "go env GOPATH" to find mod file as the "go" binary cannot be found`);


### PR DESCRIPTION
If the env var GOPATH is not set when the test runs,
now it runs `go env GOPATH` to retrieve the default value
the underlying go commands will use. I wished I could make
this command run asynchronously, but I am not familiar with
the test framework and failed to make it working with
async functions. So, like many other file operations used in
the test setup phase, I am using execFileSync.

Update  golang/vscode-go#6