### PR TITLE
github/workflow: daily release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
                golang.org/x/lint/golint \
                golang.org/x/tools/cmd/gorename
         env:
-          GO111MODULE: on   
-          
+          GO111MODULE: on
+
       - name: Install Go tools (GOPATH mode)
         run: |
           go version
@@ -60,21 +60,20 @@ jobs:
             # Because some tests depend on the source code checked in GOPATH. TODO: FIX THEM.
         env:
           GO111MODULE: off
-      
+
       - name: Prepare Release
         run: build/all.bash prepare_nightly
 
       - name: Run unit tests
         run: npm run unit-test
         continue-on-error: true
-        
+
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1.0
         with:
           run: npm run test
         env:
-          CODE_VERSION: ${{ matrix.version }}
-        continue-on-error: ${{ matrix.version == 'insiders' }}
+          CODE_VERSION: 'insiders'
 
       - name: Publish
         if: github.ref == 'refs/heads/master' && github.repository == 'golang/vscode-go'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: release
+
+# Daily release on 15:00 UTC, monday-thursday.
+# Or, force to release by triggering repository_dispatch events by using
+#   curl -v -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/golang/vscode-go/dispatches -d '{ "event_type": "force-release" }'
+on:
+  schedule:
+    - cron: "0 15 * * MON-THU"  # 15 UTC, monday-thursday daily
+  repository_dispatch:
+    types: [force-release]
+
+env:
+  GOPATH: /tmp/go
+  # Because some tests require explicit setting of GOPATH. TODO: FIX THEM.
+
+jobs:
+  release:
+    name: Release Nightly
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v1
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+         go-version: '1.14'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Go tools (Modules mode)
+        run: |
+            go version
+            go get github.com/acroca/go-symbols \
+               github.com/davidrjenni/reftools/cmd/fillstruct \
+               github.com/haya14busa/goplay/cmd/goplay \
+               github.com/mdempsky/gocode \
+               github.com/sqs/goreturns \
+               github.com/uudashr/gopkgs/v2/cmd/gopkgs \
+               github.com/zmb3/gogetdoc \
+               golang.org/x/lint/golint \
+               golang.org/x/tools/cmd/gorename
+        env:
+          GO111MODULE: on   
+          
+      - name: Install Go tools (GOPATH mode)
+        run: |
+          go version
+          go get github.com/cweill/gotests/... \
+            github.com/rogpeppe/godef \
+            github.com/ramya-rao-a/go-outline
+            # Because some tests depend on the source code checked in GOPATH. TODO: FIX THEM.
+        env:
+          GO111MODULE: off
+      
+      - name: Prepare Release
+        run: build/all.bash prepare_nightly
+
+      - name: Run unit tests
+        run: npm run unit-test
+        continue-on-error: true
+        
+      - name: Run tests
+        uses: GabrielBB/xvfb-action@v1.0
+        with:
+          run: npm run test
+        env:
+          CODE_VERSION: ${{ matrix.version }}
+        continue-on-error: ${{ matrix.version == 'insiders' }}
+
+      - name: Publish
+        if: github.ref == 'refs/heads/master' && github.repository == 'golang/vscode-go'
+        uses: lannonbr/vsce-action@704da577da0f27de5cdb4ae018374c2f08b5f523
+        with:
+          args: "publish -p $VSCE_TOKEN"
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}

--- a/build/all.bash
+++ b/build/all.bash
@@ -51,6 +51,26 @@ run_test_in_docker() {
   docker run --workdir=/workspace -v "$(pwd):/workspace" vscode-test-env ci
 }
 
+prepare_nightly() {
+  local VER=`git log -1 --format=%cd-%h --date="format:%Y.%-m.%-d"`
+  echo "**** Preparing nightly release : $VER ***"
+
+  # Update package.json
+  (cat package.json | jq --arg VER "${VER}" '
+.version=$VER |
+.preview=true |
+.name="go-nightly" |
+.displayName="Go Nightly" |
+.publisher="golang" |
+.description="Rich Go language support for Visual Studio Code (Nightly)" |
+.author.name="Go Team at Google" |
+.repository.url="https://github.com/golang/vscode-go" |
+.bugs.url="https://github.com/golang/vscode-go/issues"
+') > /tmp/package.json && mv /tmp/package.json package.json
+
+  # TODO(hyangah): Update README.md and CHANGELOG.md
+}
+
 main() {
   cd "$(root_dir)"  # always run from the script root.
   case "$1" in
@@ -69,6 +89,9 @@ main() {
       go_binaries_info
       setup_virtual_display
       run_test
+      ;;
+    "prepare_nightly")
+      prepare_nightly
       ;;
     *)
       usage

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "go-nightly",
   "displayName": "Go Nightly",
-  "version": "2020.3.144",
+  "version": "0.0.0-development",
   "publisher": "golang",
   "description": "Rich Go language support for Visual Studio Code (Nightly)",
   "author": {


### PR DESCRIPTION
Daily release workflow is triggered everyday between Mon-Thu, 15:00 UTC (11am EDT).
This prepares the version string through local modification on package.json
and runs the tests again before publishing. The newly released version has the
version string computed based on the last git commit's commit timestamp.
  <Year>.<Month>.<Day>-<Short Commit Hash>

That means, if there is no commit since the last release, the publishing step
will fail (because the MS VS Code extension market will detect the identical version).

Update golang/vscode-go#5 