### PR TITLE
Sync @ 7da5077

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ Please answer these questions before submitting your issue. Thanks!
 	- <Paste VS Code version here>
 - Check your installed extensions to get the version of the VS Code Go extension 
 	- <Paste Go extension version here>
-- Run `go env GOOS GOARCH` to get the operating system and processor arhcitecture details
+- Run `go env GOOS GOARCH` to get the operating system and processor architecture details
 	- <Paste OS and arch details here>
 
 ### Share the Go related settings you have added/edited

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -360,10 +360,17 @@ export async function promptForUpdatingTool(toolName: string) {
 	}
 	const goVersion = await getGoVersion();
 	const updateMsg = `Your version of ${tool.name} appears to be out of date. Please update for an improved experience.`;
-	vscode.window.showInformationMessage(updateMsg, 'Update').then((selected) => {
+	const choices: string[] = ['Update'];
+	if (toolName === `gopls`) {
+		choices.push('Release Notes');  // TODO(hyangah): pass more info such as version, release note location.
+	}
+	vscode.window.showInformationMessage(updateMsg, ...choices).then((selected) => {
 		switch (selected) {
 			case 'Update':
 				installTools([tool], goVersion);
+				break;
+			case 'Release Notes':
+				vscode.commands.executeCommand('vscode.open', vscode.Uri.parse('https://github.com/golang/go/issues/33030#issuecomment-510151934'));
 				break;
 			default:
 				declinedUpdates.push(tool);


### PR DESCRIPTION
 Merge 'microsoft/vscode-go/master' into 'golang/vscode-go/master'
    
    Sync @ 7da5077
    
    * master:
      Address mismatch on path separators in debug config (#2010) (#3108)
      Include the link to release note/package overview in the update prompt, and update gopls default version (#3041)
      bug_report.md: Fix "architecture" typo. (#3095)
      telemetry.ts: send telemetry only if aiKey is not an empty  string(#3091)
