### PR TITLE
github/workflows: use <year>.<month>.<day>.<hour> as version

### DIFF
--- a/build/all.bash
+++ b/build/all.bash
@@ -52,7 +52,8 @@ run_test_in_docker() {
 }
 
 prepare_nightly() {
-  local VER=`git log -1 --format=%cd-%h --date="format:%Y.%-m.%-d"`
+  local VER=`git log -1 --format=%cd --date="format:%Y.%-m.%-d.%-H"`
+  local COMMIT=`git log -1 --format=%H`
   echo "**** Preparing nightly release : $VER ***"
 
   # Update package.json
@@ -68,7 +69,8 @@ prepare_nightly() {
 .bugs.url="https://github.com/golang/vscode-go/issues"
 ') > /tmp/package.json && mv /tmp/package.json package.json
 
-  # TODO(hyangah): Update README.md and CHANGELOG.md
+  # TODO(hyangah): Update README.md
+  echo "**Release ${VER} @ ${COMMIT}** " | cat - CHANGELOG.md > /tmp/CHANGELOG.md.new && mv /tmp/CHANGELOG.md.new CHANGELOG.md
 }
 
 main() {


### PR DESCRIPTION
Marketplace does not allow prerelease annotation.
That caused the release error like
https://github.com/golang/vscode-go/runs/517074211?check_suite_focus=true

Use the four digit semver instead. Note the current `vsce package`
command allows prerelease annotation but does not allow four digit
semver format currently.

And record the commit hash to the CHANGELOG.md
since we cannot rely on the version string to encode the info.

Update golang/vscode-go#5