### PR TITLE
goMain: go.locate.tools command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "go-nightly",
   "displayName": "Go Nightly",
-  "version": "0.0.0-development",
+  "version": "0.0.0",
   "publisher": "golang",
   "description": "Rich Go language support for Visual Studio Code (Nightly)",
   "author": {
@@ -144,6 +144,11 @@
         "command": "go.gopath",
         "title": "Go: Current GOPATH",
         "description": "See the currently set GOPATH."
+      },
+      {
+        "command": "go.locate.tools",
+        "title": "Go: Locate Configured Tools",
+        "description": "List all configured tools."
       },
       {
         "command": "go.test.cursor",

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -196,16 +196,31 @@ export function activate(ctx: vscode.ExtensionContext): void {
 			outputChannel.show();
 			outputChannel.clear();
 			outputChannel.appendLine('Checking configured tools....');
+			// Tool's path search is done by getBinPathWithPreferredGopath
+			// which searches places in the following order
+			// 1) absolute path for the alternateTool
+			// 2) GOBIN
+			// 3) toolsGopath
+			// 4) gopath
+			// 5) GOROOT
+			// 6) PATH
+			outputChannel.appendLine('GOBIN: ' + process.env['GOBIN']);
+			outputChannel.appendLine('toolsGopath: ' + getToolsGopath());
+			outputChannel.appendLine('gopath: ' + getCurrentGoPath());
+			outputChannel.appendLine('GOROOT: ' + process.env['GOROOT']);
+			outputChannel.appendLine('PATH: ' + process.env['PATH']);
+			outputChannel.appendLine('');
 
 			const goVersion = await getGoVersion();
 			const allTools = getConfiguredTools(goVersion);
 
 			allTools.forEach((tool) => {
 				const toolPath = getBinPath(tool.name);
+				// TODO(hyangah): print alternate tool info if set.
 				fs.exists(toolPath, (exists) => {
 					let msg = 'not found';
 					if (exists) {
-						msg = `installed`;
+						msg = 'installed';
 					}
 					outputChannel.appendLine(`   ${tool.name}: ${toolPath} ${msg}`);
 				});


### PR DESCRIPTION
This command prints the list of configured tools and paths to the tools.
I hope this is useful when debugging the cases where multiple versions
of a tool exist in different directories.
