### PR TITLE
github/workflows: use npm install and change version to X.Y.Z format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
          go-version: '1.14'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Install Go tools (Modules mode)
         run: |

--- a/build/all.bash
+++ b/build/all.bash
@@ -52,7 +52,10 @@ run_test_in_docker() {
 }
 
 prepare_nightly() {
-  local VER=`git log -1 --format=%cd --date="format:%Y.%-m.%-d.%-H"`
+  # Version format: YYYY.MM.DDHH based on the latest commit timestamp.
+  # e.g. 2020.1.510 is the version built based on a commit that was made
+  #      on 2020/01/05 10:00
+  local VER=`git log -1 --format=%cd --date="format:%Y.%-m.%-d%H"`
   local COMMIT=`git log -1 --format=%H`
   echo "**** Preparing nightly release : $VER ***"
 


### PR DESCRIPTION
semver package is unhappy about X.Y.Z.W format of version string
and leave the extension in invalid state. Now make semver happy.

Also, use npm install to ensure all test dependencies are pulled in.