### PR TITLE
src: restart language server automatically when its configuration changes

### DIFF
--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -8,7 +8,7 @@
 import path = require('path');
 import vscode = require('vscode');
 import { goBuild } from './goBuild';
-import { parseLanguageServerConfig } from './goLanguageServer';
+import { buildLanguageServerConfig } from './goLanguageServer';
 import { goLint } from './goLint';
 import { buildDiagnosticCollection, lintDiagnosticCollection, vetDiagnosticCollection } from './goMain';
 import { isModSupported } from './goModules';
@@ -59,7 +59,7 @@ export function check(fileUri: vscode.Uri, goConfig: vscode.WorkspaceConfigurati
 
 	// If a user has enabled diagnostics via a language server,
 	// then we disable running build or vet to avoid duplicate errors and warnings.
-	const lspConfig = parseLanguageServerConfig();
+	const lspConfig = buildLanguageServerConfig();
 	const disableBuildAndVet = lspConfig.enabled && lspConfig.features.diagnostics;
 
 	let testPromise: Thenable<boolean>;

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -356,7 +356,7 @@ Please try reinstalling it.`);
  */
 export function getLanguageServerToolPath(): string {
 	const goConfig = getGoConfig();
-	if (!goConfig['useLanguageServer'] === true) {
+	if (!goConfig['useLanguageServer']) {
 		return;
 	}
 	// Check that all workspace folders are configured with the same GOPATH.

--- a/src/goLanguageServer.ts
+++ b/src/goLanguageServer.ts
@@ -70,15 +70,13 @@ let restartCommand: vscode.Disposable;
 // or falls back to the default language providers.
 export async function startLanguageServerWithFallback(ctx: vscode.ExtensionContext, activation: boolean) {
 	const cfg = buildLanguageServerConfig();
-	if (cfg.enabled) {
-		// If the language server is gopls, we can check if the user needs to
-		// update their gopls version. We do this only once per VS Code
-		// activation to avoid inundating the user.
-		if (activation && cfg.serverName === 'gopls') {
-			const tool = getTool(cfg.serverName);
-			if (!tool) {
-				return false;
-			}
+
+	// If the language server is gopls, we can check if the user needs to
+	// update their gopls version. We do this only once per VS Code
+	// activation to avoid inundating the user.
+	if (activation && cfg.enabled && cfg.serverName === 'gopls') {
+		const tool = getTool(cfg.serverName);
+		if (tool) {
 			const versionToUpdate = await shouldUpdateLanguageServer(tool, cfg.path, cfg.checkForUpdates);
 			if (versionToUpdate) {
 				promptForUpdatingTool(tool.name);

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -13,76 +13,43 @@ import { buildCode } from './goBuild';
 import { check, notifyIfGeneratedFile, removeTestStatus } from './goCheck';
 import { GoCodeActionProvider } from './goCodeAction';
 import {
-	applyCodeCoverage,
-	applyCodeCoverageToAllEditors,
-	initCoverageDecorators,
-	removeCodeCoverageOnFileSave,
-	toggleCoverageCurrentPackage,
-	trackCodeCoverageRemovalOnFileChange,
-	updateCodeCoverageDecorators
+	applyCodeCoverage, applyCodeCoverageToAllEditors, initCoverageDecorators, removeCodeCoverageOnFileSave,
+	toggleCoverageCurrentPackage, trackCodeCoverageRemovalOnFileChange, updateCodeCoverageDecorators
 } from './goCover';
 import { GoDebugConfigurationProvider } from './goDebugConfiguration';
-import { GoDefinitionProvider } from './goDeclaration';
 import { extractFunction, extractVariable } from './goDoctor';
-import { GoHoverProvider } from './goExtraInfo';
 import { runFillStruct } from './goFillStruct';
-import { GoDocumentFormattingEditProvider } from './goFormat';
 import * as goGenerateTests from './goGenerateTests';
 import { goGetPackage } from './goGetPackage';
 import { implCursor } from './goImpl';
-import { GoImplementationProvider } from './goImplementations';
 import { addImport, addImportToWorkspace } from './goImport';
 import { installCurrentPackage } from './goInstall';
 import {
-	installAllTools,
-	installTools,
-	offerToInstallTools,
-	promptForMissingTool,
+	installAllTools, installTools, offerToInstallTools, promptForMissingTool,
 	updateGoPathGoRootFromConfig
 } from './goInstallTools';
 import { registerLanguageFeatures } from './goLanguageServer';
 import { lintCode } from './goLint';
-import { parseLiveFile } from './goLiveErrors';
 import { GO_MODE } from './goMode';
 import { addTags, removeTags } from './goModifytags';
 import { GO111MODULE, isModSupported } from './goModules';
-import { GoDocumentSymbolProvider } from './goOutline';
 import { clearCacheForTools, fileExists } from './goPath';
 import { playgroundCommand } from './goPlayground';
-import { GoReferenceProvider } from './goReferences';
 import { GoReferencesCodeLensProvider } from './goReferencesCodelens';
-import { GoRenameProvider } from './goRename';
 import { GoRunTestCodeLensProvider } from './goRunTestCodelens';
-import { GoSignatureHelpProvider } from './goSignature';
 import { outputChannel, showHideStatus } from './goStatus';
-import { GoCompletionItemProvider } from './goSuggest';
-import { GoWorkspaceSymbolProvider } from './goSymbol';
 import { testAtCursor, testCurrentFile, testCurrentPackage, testPrevious, testWorkspace } from './goTest';
 import { getConfiguredTools } from './goTools';
-import { GoTypeDefinitionProvider } from './goTypeDefinition';
 import { vetCode } from './goVet';
 import {
-	getFromGlobalState,
-	getFromWorkspaceState,
-	setGlobalState,
-	setWorkspaceState,
-	updateGlobalState,
+	getFromGlobalState, getFromWorkspaceState, setGlobalState, setWorkspaceState, updateGlobalState,
 	updateWorkspaceState
 } from './stateUtils';
 import { disposeTelemetryReporter, sendTelemetryEventForConfig } from './telemetry';
 import { cancelRunningTests, showTestOutput } from './testUtils';
 import {
-	cleanupTempDir,
-	getBinPath,
-	getCurrentGoPath,
-	getExtensionCommands,
-	getGoConfig,
-	getGoVersion,
-	getToolsEnvVars,
-	getToolsGopath,
-	getWorkspaceFolderPath,
-	handleDiagnosticErrors,
-	isGoPathSet
+	cleanupTempDir, getBinPath, getCurrentGoPath, getExtensionCommands, getGoConfig,
+	getGoVersion, getToolsEnvVars, getToolsGopath, getWorkspaceFolderPath, handleDiagnosticErrors, isGoPathSet
 } from './util';
 
 export let buildDiagnosticCollection: vscode.DiagnosticCollection;
@@ -147,10 +114,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 		// This handles all of the configurations and registrations for the language server.
 		// It also registers the necessary language feature providers that the language server may not support.
-		const ok = await registerLanguageFeatures(ctx);
-		if (!ok) {
-			registerUsualProviders(ctx);
-		}
+		await registerLanguageFeatures(ctx);
 
 		if (
 			vscode.window.activeTextEditor &&
@@ -621,28 +585,6 @@ function addOnSaveTextDocumentListeners(ctx: vscode.ExtensionContext) {
 		null,
 		ctx.subscriptions
 	);
-}
-
-// registerUsualProviders registers the language feature providers if the language server is not enabled.
-function registerUsualProviders(ctx: vscode.ExtensionContext) {
-	const provider = new GoCompletionItemProvider(ctx.globalState);
-	ctx.subscriptions.push(provider);
-	ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(GO_MODE, provider, '.', '"'));
-	ctx.subscriptions.push(vscode.languages.registerHoverProvider(GO_MODE, new GoHoverProvider()));
-	ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(GO_MODE, new GoDefinitionProvider()));
-	ctx.subscriptions.push(vscode.languages.registerReferenceProvider(GO_MODE, new GoReferenceProvider()));
-	ctx.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(GO_MODE, new GoDocumentSymbolProvider()));
-	ctx.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new GoWorkspaceSymbolProvider()));
-	ctx.subscriptions.push(
-		vscode.languages.registerSignatureHelpProvider(GO_MODE, new GoSignatureHelpProvider(), '(', ',')
-	);
-	ctx.subscriptions.push(vscode.languages.registerImplementationProvider(GO_MODE, new GoImplementationProvider()));
-	ctx.subscriptions.push(
-		vscode.languages.registerDocumentFormattingEditProvider(GO_MODE, new GoDocumentFormattingEditProvider())
-	);
-	ctx.subscriptions.push(vscode.languages.registerTypeDefinitionProvider(GO_MODE, new GoTypeDefinitionProvider()));
-	ctx.subscriptions.push(vscode.languages.registerRenameProvider(GO_MODE, new GoRenameProvider()));
-	vscode.workspace.onDidChangeTextDocument(parseLiveFile, null, ctx.subscriptions);
 }
 
 function addOnChangeTextDocumentListeners(ctx: vscode.ExtensionContext) {

--- a/src/goModules.ts
+++ b/src/goModules.ts
@@ -7,6 +7,7 @@ import cp = require('child_process');
 import path = require('path');
 import vscode = require('vscode');
 import { installTools } from './goInstallTools';
+import { restartLanguageServer } from './goLanguageServer';
 import { envPath, fixDriveCasingInWindows } from './goPath';
 import { getTool } from './goTools';
 import { getFromGlobalState, updateGlobalState } from './stateUtils';
@@ -135,12 +136,7 @@ export async function promptToUpdateToolForModules(
 						if (goConfig.inspect('useLanguageServer').workspaceFolderValue === false) {
 							goConfig.update('useLanguageServer', true, vscode.ConfigurationTarget.WorkspaceFolder);
 						}
-						const reloadMsg = 'Reload VS Code window to enable the use of Go language server';
-						vscode.window.showInformationMessage(reloadMsg, 'Reload').then((selectedForReload) => {
-							if (selectedForReload === 'Reload') {
-								vscode.commands.executeCommand('workbench.action.reloadWindow');
-							}
-						});
+						restartLanguageServer();
 					}
 				});
 			}

--- a/src/goModules.ts
+++ b/src/goModules.ts
@@ -7,7 +7,7 @@ import cp = require('child_process');
 import path = require('path');
 import vscode = require('vscode');
 import { installTools } from './goInstallTools';
-import { restartLanguageServer } from './goLanguageServer';
+import { restartLanguageServer } from './goMain';
 import { envPath, fixDriveCasingInWindows } from './goPath';
 import { getTool } from './goTools';
 import { getFromGlobalState, updateGlobalState } from './stateUtils';


### PR DESCRIPTION
This change replaces the messages that tell the user to reload with automatic calls to the restart function. This way, config changes are automatically reflected - I tested it out locally and it worked pretty nicely. Most of the code to do this was already there, it was just a matter of reordering it correctly and making sure to deregister/re-register the default providers. I also added the mtime check for the language server binary as part of the config.

The only other thing that might be still missing is automatic restarts when the language server binary changes on disk, but that might be too much - probably wouldn't be intuitive for the user.

After this is merged, it will be really simple to implement #3128.

Sorry about the huge PR! It's a lot of code shuffling, and there's one function that I moved back to its original place after #3186 - sorry about that!

/cc @hyangah