### PR TITLE
Add logic to infer remote path automatically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -402,6 +402,11 @@
         "readdirp": "~3.2.0"
       }
     },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -1226,8 +1231,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -1524,6 +1528,11 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
+    },
+    "postinstall-build": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/postinstall-build/-/postinstall-build-5.0.3.tgz",
+      "integrity": "sha512-vPvPe8TKgp4FLgY3+DfxCE5PIfoXBK2lyLfNCxsRbDsV6vS4oU5RG/IWxrblMn6heagbnMED3MemUQllQ2bQUg=="
     },
     "prettier": {
       "version": "2.0.4",
@@ -1872,6 +1881,16 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
+    },
+    "typemoq": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typemoq/-/typemoq-2.1.0.tgz",
+      "integrity": "sha512-DtRNLb7x8yCTv/KHlwes+NI+aGb4Vl1iPC63Hhtcvk1DpxSAZzKWQv0RQFY0jX2Uqj0SDBNl8Na4e6MV6TNDgw==",
+      "requires": {
+        "circular-json": "^0.3.1",
+        "lodash": "^4.17.4",
+        "postinstall-build": "^5.0.1"
+      }
     },
     "typescript": {
       "version": "3.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -402,11 +402,6 @@
         "readdirp": "~3.2.0"
       }
     },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
-    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -1231,7 +1226,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -1528,11 +1524,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
-    },
-    "postinstall-build": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postinstall-build/-/postinstall-build-5.0.3.tgz",
-      "integrity": "sha512-vPvPe8TKgp4FLgY3+DfxCE5PIfoXBK2lyLfNCxsRbDsV6vS4oU5RG/IWxrblMn6heagbnMED3MemUQllQ2bQUg=="
     },
     "prettier": {
       "version": "2.0.4",
@@ -1881,16 +1872,6 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
-    },
-    "typemoq": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typemoq/-/typemoq-2.1.0.tgz",
-      "integrity": "sha512-DtRNLb7x8yCTv/KHlwes+NI+aGb4Vl1iPC63Hhtcvk1DpxSAZzKWQv0RQFY0jX2Uqj0SDBNl8Na4e6MV6TNDgw==",
-      "requires": {
-        "circular-json": "^0.3.1",
-        "lodash": "^4.17.4",
-        "postinstall-build": "^5.0.1"
-      }
     },
     "typescript": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "moment": "^2.24.0",
     "semver": "^7.3.2",
     "tree-kill": "^1.2.2",
-    "typemoq": "^2.1.0",
     "vscode-debugadapter": "^1.40.0",
     "vscode-debugprotocol": "^1.40.0",
     "vscode-extension-telemetry": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -40,17 +40,18 @@
   },
   "extensionDependencies": [],
   "dependencies": {
+    "deep-equal": "^2.0.2",
     "diff": "^4.0.2",
     "json-rpc2": "^1.0.2",
     "moment": "^2.24.0",
     "semver": "^7.3.2",
     "tree-kill": "^1.2.2",
+    "typemoq": "^2.1.0",
     "vscode-debugadapter": "^1.40.0",
     "vscode-debugprotocol": "^1.40.0",
     "vscode-extension-telemetry": "^0.1.2",
     "vscode-languageclient": "6.1.0",
-    "web-request": "^1.0.7",
-    "deep-equal": "^2.0.2"
+    "web-request": "^1.0.7"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1020,7 +1020,7 @@ export class GoDebugSession extends LoggingDebugSession {
 			return localGoPathImportPath;
 		}
 
-		// Scenario 4: The package is inside GOROOT.
+		// Scenario 3: The package is inside GOROOT.
 		return this.inferLocalPathInGoRootFromRemoteGoPackage(pathToConvertWithLocalSeparator, relativeRemotePath);
 	}
 
@@ -1032,7 +1032,7 @@ export class GoDebugSession extends LoggingDebugSession {
 	protected inferLocalPathInGoRootFromRemoteGoPackage(
 			remotePathWithLocalSeparator: string, relativeRemotePath: string): string|undefined {
 		const srcIndex = remotePathWithLocalSeparator.indexOf(`${this.localPathSeparator}src${this.localPathSeparator}`);
-		const goroot = process.env['GOROOT'];
+		const goroot = process.env['GOROOT'] || '';
 		const localGoRootImportPath = path.join(
 			goroot,
 			srcIndex >= 0
@@ -1053,7 +1053,7 @@ export class GoDebugSession extends LoggingDebugSession {
 	 */
 	protected inferLocalPathInGoPathFromRemoteGoPackage(
 			remotePathWithLocalSeparator: string, relativeRemotePath: string): string|undefined {
-		// Scenario 1: The package is inside GOPATH.
+		// Scenario 1: The package is inside $GOPATH/pkg/mod.
 		const gopath = (process.env['GOPATH'] || '').split(path.delimiter)[0];
 
 		const indexGoModCache = remotePathWithLocalSeparator.indexOf(
@@ -1068,7 +1068,7 @@ export class GoDebugSession extends LoggingDebugSession {
 			return localGoPathImportPath;
 		}
 
-		// Scenario 2: The file is in a package in GOPATH/src.
+		// Scenario 2: The file is in a package in $GOPATH/src.
 		const localGoPathSrcPath = path.join(
 				gopath, 'src',
 				relativeRemotePath.split(this.remotePathSeparator).join(this.localPathSeparator));

--- a/test/integration/goDebug.test.ts
+++ b/test/integration/goDebug.test.ts
@@ -11,7 +11,7 @@ suite('Path Manipulation Tests', () => {
 	});
 });
 
-suite.only('GoDebugSession Tests', () => {
+suite('GoDebugSession Tests', () => {
 	const workspaceFolder = '/usr/workspacefolder';
 	const delve: Delve = {} as Delve;
 	const previousGoPath = process.env.GOPATH;

--- a/test/integration/goDebug.test.ts
+++ b/test/integration/goDebug.test.ts
@@ -1,0 +1,264 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import {IMock, Mock} from 'typemoq';
+import { Delve, escapeGoModPath, GoDebugSession,
+	PackageBuildInfo, RemoteSourcesAndPackages } from '../../src/debugAdapter/goDebug';
+
+suite('Path Manipulation Tests', () => {
+	test('escapeGoModPath works', () => {
+		assert.strictEqual(escapeGoModPath('BurnSushi/test.go'), '!burn!sushi/test.go');
+	});
+});
+
+suite('GoDebugSession Tests', () => {
+	const workspaceFolder = '/usr/workspacefolder';
+
+	let goDebugSession: GoDebugSession;
+	let remoteSourcesAndPackagesMock: IMock<RemoteSourcesAndPackages>;
+	let fileSystemMock: IMock<typeof fs>;
+	let delve: IMock<Delve>;
+	setup(() => {
+		remoteSourcesAndPackagesMock = Mock.ofType<RemoteSourcesAndPackages>();
+		fileSystemMock = Mock.ofType<typeof fs>();
+		delve = Mock.ofType<Delve>();
+		delve.setup((mock) => mock.program).returns(() => workspaceFolder);
+		goDebugSession = new GoDebugSession(true, false, fileSystemMock.object);
+		goDebugSession['delve'] = delve.object;
+		goDebugSession['remoteSourcesAndPackages'] = remoteSourcesAndPackagesMock.object;
+	});
+
+	test('inferRemotePathFromLocalPath works', () => {
+		const sourceFileMapping = new Map<string, string[]>();
+		sourceFileMapping.set('main.go', ['/app/hello-world/main.go', '/app/main.go']);
+		sourceFileMapping.set('blah.go', ['/app/blah.go']);
+
+		remoteSourcesAndPackagesMock.setup((mock) => mock.remoteSourceFilesNameGrouping)
+			.returns(() => (sourceFileMapping));
+
+		const inferredPath = goDebugSession['inferRemotePathFromLocalPath'](
+			'C:\\Users\\Documents\\src\\hello-world\\main.go');
+		assert.strictEqual(inferredPath, '/app/hello-world/main.go');
+	});
+
+	test('inferLocalPathFromRemoteGoPackage works for package in workspaceFolder', () => {
+		const remotePath = '/src/hello-world/morestrings/morestrings.go';
+		const helloPackage: PackageBuildInfo = {
+			ImportPath: 'hello-world/morestrings',
+			DirectoryPath: '/src/hello-world/morestrings',
+			Files: ['/src/hello-world/morestrings/lessstrings.go', '/src/hello-world/morestrings/morestrings.go']
+		};
+
+		const testPackage: PackageBuildInfo = {
+			ImportPath: 'FooBar/test',
+			DirectoryPath: 'remote/pkg/mod/!foo!bar/test@v1.0.2',
+			Files: ['remote/pkg/mod/!foo!bar/test@v1.0.2/test.go']
+		};
+
+		process.env.GOPATH = '/usr/go';
+		const localPath = path.join(workspaceFolder, 'hello-world/morestrings/morestrings.go');
+		fileSystemMock.setup((mock) => mock.existsSync(localPath))
+			.returns(() => true);
+
+		remoteSourcesAndPackagesMock.setup((mock) => mock.remotePackagesBuildInfo)
+			.returns(() => [helloPackage, testPackage]);
+
+		goDebugSession['localPathSeparator'] = '/';
+		const inferredLocalPath = goDebugSession['inferLocalPathFromRemoteGoPackage'](remotePath);
+		assert.strictEqual(inferredLocalPath, localPath);
+	});
+
+	test('inferLocalPathFromRemoteGoPackage works for package in GOPATH/pkg/mod', () => {
+		const remotePath = 'remote/pkg/mod/!foo!bar/test@v1.0.2/test.go';
+		const helloPackage: PackageBuildInfo = {
+			ImportPath: 'hello-world',
+			DirectoryPath: '/src/hello-world',
+			Files: ['src/hello-world/hello.go', 'src/hello-world/world.go']
+		};
+
+		const testPackage: PackageBuildInfo = {
+			ImportPath: 'FooBar/test',
+			DirectoryPath: 'remote/pkg/mod/!foo!bar/test@v1.0.2',
+			Files: ['remote/pkg/mod/!foo!bar/test@v1.0.2/test.go']
+		};
+
+		process.env.GOPATH = '/usr/go';
+		const localPath = path.join(process.env.GOPATH, 'pkg/mod/!foo!bar/test@v1.0.2/test.go');
+		fileSystemMock.setup((mock) => mock.existsSync(localPath))
+			.returns(() => true);
+
+		remoteSourcesAndPackagesMock.setup((mock) => mock.remotePackagesBuildInfo)
+			.returns(() => [helloPackage, testPackage]);
+
+		goDebugSession['localPathSeparator'] = '/';
+		const inferredLocalPath = goDebugSession['inferLocalPathFromRemoteGoPackage'](remotePath);
+		assert.strictEqual(inferredLocalPath, localPath);
+	});
+
+	test('inferLocalPathFromRemoteGoPackage works for package in GOPATH/pkg/mod with relative path', () => {
+		const remotePath = '!foo!bar/test@v1.0.2/test.go';
+		const helloPackage: PackageBuildInfo = {
+			ImportPath: 'hello-world',
+			DirectoryPath: '/src/hello-world',
+			Files: ['src/hello-world/hello.go', 'src/hello-world/world.go']
+		};
+
+		const testPackage: PackageBuildInfo = {
+			ImportPath: 'FooBar/test',
+			DirectoryPath: '!foo!bar/test@v1.0.2',
+			Files: ['!foo!bar/test@v1.0.2/test.go']
+		};
+
+		process.env.GOPATH = '/usr/go';
+		const localPath = path.join(process.env.GOPATH, 'pkg/mod/!foo!bar/test@v1.0.2/test.go');
+		fileSystemMock.setup((mock) => mock.existsSync(localPath))
+			.returns(() => true);
+
+		remoteSourcesAndPackagesMock.setup((mock) => mock.remotePackagesBuildInfo)
+			.returns(() => [helloPackage, testPackage]);
+
+		goDebugSession['localPathSeparator'] = '/';
+		const inferredLocalPath = goDebugSession['inferLocalPathFromRemoteGoPackage'](remotePath);
+		assert.strictEqual(inferredLocalPath, localPath);
+	});
+
+	test('inferLocalPathFromRemoteGoPackage works for package in GOPATH/src', () => {
+		const remotePath = 'remote/gopath/src/foobar/test@v1.0.2/test.go';
+		const helloPackage: PackageBuildInfo = {
+			ImportPath: 'hello-world',
+			DirectoryPath: '/src/hello-world',
+			Files: ['src/hello-world/hello.go', 'src/hello-world/world.go']
+		};
+
+		const testPackage: PackageBuildInfo = {
+			ImportPath: 'foobar/test',
+			DirectoryPath: 'remote/gopath/src/foobar/test@v1.0.2',
+			Files: ['remote/gopath/src/foobar/test@v1.0.2/test.go']
+		};
+
+		process.env.GOPATH = '/usr/go';
+		const localPath = path.join(process.env.GOPATH, 'src', 'foobar/test@v1.0.2/test.go');
+		fileSystemMock.setup((mock) => mock.existsSync(localPath))
+			.returns(() => true);
+
+		remoteSourcesAndPackagesMock.setup((mock) => mock.remotePackagesBuildInfo)
+			.returns(() => [helloPackage, testPackage]);
+
+		goDebugSession['localPathSeparator'] = '/';
+		const inferredLocalPath = goDebugSession['inferLocalPathFromRemoteGoPackage'](remotePath);
+		assert.strictEqual(inferredLocalPath, localPath);
+	});
+
+	test('inferLocalPathFromRemoteGoPackage works for package in GOPATH/src with relative path', () => {
+		const remotePath = 'foobar/test@v1.0.2/test.go';
+		const helloPackage: PackageBuildInfo = {
+			ImportPath: 'hello-world',
+			DirectoryPath: '/src/hello-world',
+			Files: ['src/hello-world/hello.go', 'src/hello-world/world.go']
+		};
+
+		const testPackage: PackageBuildInfo = {
+			ImportPath: 'foobar/test',
+			DirectoryPath: 'foobar/test@v1.0.2',
+			Files: ['foobar/test@v1.0.2/test.go']
+		};
+
+		process.env.GOPATH = '/usr/go';
+		const localPath = path.join(process.env.GOPATH, 'src', 'foobar/test@v1.0.2/test.go');
+		fileSystemMock.setup((mock) => mock.existsSync(localPath))
+			.returns(() => true);
+
+		remoteSourcesAndPackagesMock.setup((mock) => mock.remotePackagesBuildInfo)
+			.returns(() => [helloPackage, testPackage]);
+
+		goDebugSession['localPathSeparator'] = '/';
+		const inferredLocalPath = goDebugSession['inferLocalPathFromRemoteGoPackage'](remotePath);
+		assert.strictEqual(inferredLocalPath, localPath);
+	});
+
+	test('inferLocalPathFromRemoteGoPackage works for package in GOROOT/src', () => {
+		const remotePath = 'remote/goroot/src/foobar/test@v1.0.2/test.go';
+		const helloPackage: PackageBuildInfo = {
+			ImportPath: 'hello-world',
+			DirectoryPath: '/src/hello-world',
+			Files: ['src/hello-world/hello.go', 'src/hello-world/world.go']
+		};
+
+		const testPackage: PackageBuildInfo = {
+			ImportPath: 'foobar/test',
+			DirectoryPath: 'remote/goroot/src/foobar/test@v1.0.2',
+			Files: ['remote/goroot/src/foobar/test@v1.0.2/test.go']
+		};
+
+		process.env.GOROOT = '/usr/go';
+		const localPath = path.join(process.env.GOROOT, 'src', 'foobar/test@v1.0.2/test.go');
+		fileSystemMock.setup((mock) => mock.existsSync(localPath))
+			.returns(() => true);
+
+		remoteSourcesAndPackagesMock.setup((mock) => mock.remotePackagesBuildInfo)
+			.returns(() => [helloPackage, testPackage]);
+
+		goDebugSession['localPathSeparator'] = '/';
+		const inferredLocalPath = goDebugSession['inferLocalPathFromRemoteGoPackage'](remotePath);
+		assert.strictEqual(inferredLocalPath, localPath);
+	});
+
+	test('inferLocalPathFromRemoteGoPackage works for package in GOROOT/src with relative path', () => {
+		const remotePath = 'foobar/test@v1.0.2/test.go';
+		const helloPackage: PackageBuildInfo = {
+			ImportPath: 'hello-world',
+			DirectoryPath: '/src/hello-world',
+			Files: ['src/hello-world/hello.go', 'src/hello-world/world.go']
+		};
+
+		const testPackage: PackageBuildInfo = {
+			ImportPath: 'foobar/test',
+			DirectoryPath: 'foobar/test@v1.0.2',
+			Files: ['foobar/test@v1.0.2/test.go']
+		};
+
+		process.env.GOROOT = '/usr/go';
+		const localPath = path.join(process.env.GOROOT, 'src', 'foobar/test@v1.0.2/test.go');
+		fileSystemMock.setup((mock) => mock.existsSync(localPath))
+			.returns(() => true);
+
+		remoteSourcesAndPackagesMock.setup((mock) => mock.remotePackagesBuildInfo)
+			.returns(() => [helloPackage, testPackage]);
+
+		goDebugSession['localPathSeparator'] = '/';
+		const inferredLocalPath = goDebugSession['inferLocalPathFromRemoteGoPackage'](remotePath);
+		assert.strictEqual(inferredLocalPath, localPath);
+	});
+});
+
+suite('RemoteSourcesAndPackages Tests', () => {
+	const helloPackage: PackageBuildInfo = {
+		ImportPath: 'hello-world',
+		DirectoryPath: '/src/hello-world',
+		Files: ['src/hello-world/hello.go', 'src/hello-world/world.go']
+	};
+	const testPackage: PackageBuildInfo = {
+		ImportPath: 'test',
+		DirectoryPath: '/src/test',
+		Files: ['src/test/test.go']
+	};
+	const sources = ['src/hello-world/hello.go', 'src/hello-world/world.go', 'src/test/test.go'];
+	let remoteSourcesAndPackages: RemoteSourcesAndPackages;
+	let delve: IMock<Delve>;
+	setup(() => {
+		delve = Mock.ofType<Delve>();
+		delve.setup((mock) => mock.isApiV1).returns(() => false);
+		remoteSourcesAndPackages = new RemoteSourcesAndPackages();
+	});
+
+	test('initializeRemotePackagesAndSources retrieves remote packages and sources', async () => {
+		delve.setup((mock) => mock.callPromise('ListPackagesBuildInfo', [{IncludeFiles: true}]))
+			.returns(() => Promise.resolve({List: [helloPackage, testPackage]}));
+		delve.setup((mock) => mock.callPromise('ListSources', [{}]))
+			.returns(() => Promise.resolve({Sources: sources}));
+
+		await remoteSourcesAndPackages.initializeRemotePackagesAndSources(delve.object);
+		assert.deepEqual(remoteSourcesAndPackages.remoteSourceFiles, sources);
+		assert.deepEqual(remoteSourcesAndPackages.remotePackagesBuildInfo, [helloPackage, testPackage]);
+	});
+});


### PR DESCRIPTION
Delve has an [API](https://godoc.org/github.com/go-delve/delve/service/rpc2#ListSourcesOut) to list all the files used by the program. So we can simply get the list of files on the remote machine and map it to the files on the local machine. These include files in the `GOROOT` and `GOPATH` on the remote machine as well so we can try to map them to the files in the local machine `GOROOT` and `GOPATH`.

## Mapping local path to remote path
Since we get all the remote sources, we can retrieve all the remote source files that share the same file name with the local file. We can then do a suffix match to get the best matching remote path.
Mapping remote path to local path
This is more complicated because there are multiple places where we can try to find a match on the local machine.

However, we can use the [`ListPackagesBuildInfo`](https://godoc.org/github.com/go-delve/delve/service/rpc2#ListPackagesBuildInfoOut) to help us retrieve all the different Go packages used. Each package item returned comes with a Directory Path and an Import Path. Using Directory Path, we can determine if the remote path is in a particular package or not:

- If the remote path is in a package, we can try to find whether the package exists on the local machine. We will be searching for it in 3 places:
    - The current user’s workspace folder.
    - The current user’s `GOPATH`.
    - The current user’s `GOMOD` folder (`%GOMOD%/pkg/mod`) if the package name contains `pkg/mod`.

- If the remote path is not in any package, then we retrieve the name of the remote path and search for files with that name in the current workspace folder. We find the best matching one using a suffix match.

Updates golang/vscode-go#45.