### PR TITLE
src/goCheck.ts: relax generated code detection rule

### DIFF
--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -21,6 +21,8 @@ const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignmen
 statusBarItem.command = 'go.test.showOutput';
 const neverAgain = { title: `Don't Show Again` };
 
+const filesLookupTbl: { [id: string ]: number; } = {};
+
 export function removeTestStatus(e: vscode.TextDocumentChangeEvent) {
 	if (e.document.isUntitled) {
 		return;
@@ -51,8 +53,6 @@ export function notifyIfGeneratedFile(this: void, e: vscode.TextDocumentChangeEv
 		return !!text.match(/^\/\/ .*DO NOT EDIT\.?$/);
 	};
 
-	const filesLookupTbl: { [id: string ]: number; } = ctx.workspaceState.get( 'lookupsGenerated' ) || {};
-
 	if ( filesLookupTbl[e.document.fileName] ) {
 		const previous = filesLookupTbl[e.document.fileName];
 		if ( previous <= e.document.lineCount && isGenerated( e.document.lineAt( previous ).text ) ) {
@@ -64,9 +64,8 @@ export function notifyIfGeneratedFile(this: void, e: vscode.TextDocumentChangeEv
 	for ( let line = 0; line < e.document.lineCount; line++ ) {
 		if ( e.document.lineAt(line).text.match( '^\s*$' ) ) {
 			continue;
-		} else if ( e.document.lineAt(line).text.slice(0, 2) === '//' && isGenerated(e.document.lineAt(line).text) ) {
+		} else if ( e.document.lineAt(line).text.startsWith('//') && isGenerated(e.document.lineAt(line).text) ) {
 			filesLookupTbl[e.document.fileName] = line;
-			ctx.workspaceState.update( 'lookupsGenerated', filesLookupTbl);
 			vscode.window.showWarningMessage(doNotEditMessage, neverAgain).then(maybeSaveNeverAgain);
 			return;
 		}

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -51,7 +51,7 @@ export function notifyIfGeneratedFile(this: void, e: vscode.TextDocumentChangeEv
 		return !!text.match(/^\/\/ .*DO NOT EDIT\.?$/);
 	};
 
-	const filesLookupTbl: { [id: string ]: number; } = ctx.globalState.get( 'lookupsGenerated' ) || {};
+	const filesLookupTbl: { [id: string ]: number; } = ctx.workspaceState.get( 'lookupsGenerated' ) || {};
 
 	if ( filesLookupTbl[e.document.fileName] ) {
 		const previous = filesLookupTbl[e.document.fileName];
@@ -66,7 +66,7 @@ export function notifyIfGeneratedFile(this: void, e: vscode.TextDocumentChangeEv
 			continue;
 		} else if ( e.document.lineAt(line).text.slice(0, 2) === '//' && isGenerated(e.document.lineAt(line).text) ) {
 			filesLookupTbl[e.document.fileName] = line;
-			ctx.globalState.update( 'lookupsGenerated', filesLookupTbl);
+			ctx.workspaceState.update( 'lookupsGenerated', filesLookupTbl);
 			vscode.window.showWarningMessage(doNotEditMessage, neverAgain).then(maybeSaveNeverAgain);
 			return;
 		}

--- a/src/goCheck.ts
+++ b/src/goCheck.ts
@@ -31,18 +31,45 @@ export function removeTestStatus(e: vscode.TextDocumentChangeEvent) {
 
 export function notifyIfGeneratedFile(this: void, e: vscode.TextDocumentChangeEvent) {
 	const ctx: any = this;
+
 	if (e.document.isUntitled || e.document.languageId !== 'go') {
 		return;
 	}
-	if (
-		ctx.globalState.get('ignoreGeneratedCodeWarning') !== true &&
-		e.document.lineAt(0).text.match(/^\/\/ Code generated .* DO NOT EDIT\.$/)
-	) {
-		vscode.window.showWarningMessage('This file seems to be generated. DO NOT EDIT.', neverAgain).then((result) => {
-			if (result === neverAgain) {
-				ctx.globalState.update('ignoreGeneratedCodeWarning', true);
-			}
-		});
+
+	if ( ctx.globalState.get('ignoreGeneratedCodeWarning') === true ) {
+		return;
+	}
+
+	const doNotEditMessage = 'This file seems to be generated. DO NOT EDIT.';
+	const maybeSaveNeverAgain = (result: object) => {
+		if (result === neverAgain) {
+			ctx.globalState.update('ignoreGeneratedCodeWarning', true);
+		}
+	};
+
+	const isGenerated = (text: string): boolean => {
+		return !!text.match(/^\/\/ .*DO NOT EDIT\.?$/);
+	};
+
+	const filesLookupTbl: { [id: string ]: number; } = ctx.globalState.get( 'lookupsGenerated' ) || {};
+
+	if ( filesLookupTbl[e.document.fileName] ) {
+		const previous = filesLookupTbl[e.document.fileName];
+		if ( previous <= e.document.lineCount && isGenerated( e.document.lineAt( previous ).text ) ) {
+			vscode.window.showWarningMessage(doNotEditMessage, neverAgain).then( maybeSaveNeverAgain );
+			return;
+		}
+	}
+
+	for ( let line = 0; line < e.document.lineCount; line++ ) {
+		if ( e.document.lineAt(line).text.match( '^\s*$' ) ) {
+			continue;
+		} else if ( e.document.lineAt(line).text.slice(0, 2) === '//' && isGenerated(e.document.lineAt(line).text) ) {
+			filesLookupTbl[e.document.fileName] = line;
+			ctx.globalState.update( 'lookupsGenerated', filesLookupTbl);
+			vscode.window.showWarningMessage(doNotEditMessage, neverAgain).then(maybeSaveNeverAgain);
+			return;
+		}
 	}
 }
 


### PR DESCRIPTION
Implements set of changes that enhance user experience with generated go files.

1) It allows checking other (then) the first line of the file for target msg.
2) It uses a lookup table to cache results of previous checks
3) it changes regexp pattern
   from
   `/^// Code generated .* DO NOT EDIT.$

   to
   `^// .*DO NOT EDIT.?`

  Aiming to show generated message to files also available in go codebase, 
  that does not follow the standard "generated" pattern.

  Fixes golang/vscode-go#68