### PR TITLE
src/goCover: clear cached coverage info on save

### DIFF
--- a/src/goCover.ts
+++ b/src/goCover.ts
@@ -32,7 +32,7 @@ let decoratorConfig: {
 // a list of modified, unsaved go files with actual code edits (rather than comment edits)
 let modifiedFiles: {
 	[key: string]: boolean;
-};
+} = {};
 
 /**
  * Initializes the decorators used for Code coverage.
@@ -298,7 +298,7 @@ export function applyCodeCoverage(editor: vscode.TextEditor) {
  * @param e TextDocument
  */
 export function removeCodeCoverageOnFileSave(e: vscode.TextDocument) {
-	if (e.languageId !== 'go' || !isCoverageApplied || !e.isDirty) {
+	if (e.languageId !== 'go' || !isCoverageApplied) {
 		return;
 	}
 


### PR DESCRIPTION
This is a fix for the regression in ms-vscode.Go@0.14.2

The `isDirty` bit of the TextDocument when vscode.workspace.onDidSaveTextDocument is
already false.  Adjust the condition for clearing cache not to check it.
Modification should be tracked already by trackCodeCoverageRemovalOnFileChange.

And let modifiedFiles start with an empty value rather than as undefined.

Fixes https://github.com/microsoft/vscode-go/issues/3252.
