### PR TITLE
tests/gopls: allow completion tests to run asynchronously

### DIFF
--- a/test/gopls/extension.test.ts
+++ b/test/gopls/extension.test.ts
@@ -132,7 +132,7 @@ suite('Go Extension Tests With Gopls', function () {
 				&& (!expectedDoc || gotMessage.includes(expectedDoc)),
 				`check hovers over ${name} failed: got ${gotMessage}`);
 		});
-		return Promise.all(promises);
+		await Promise.all(promises);
 	});
 
 	test('Completion middleware', async () => {
@@ -141,7 +141,7 @@ suite('Go Extension Tests With Gopls', function () {
 		const testCases: [string, vscode.Position, string][] = [
 			['fmt.<>', new vscode.Position(19, 5), 'Formatter'],
 		];
-		for (const [name, position, wantFilterText] of testCases) {
+		const promises = testCases.map(async ([name, position, wantFilterText]) => {
 			const list = await vscode.commands.executeCommand(
 				'vscode.executeCompletionItemProvider', uri, position) as vscode.CompletionList;
 
@@ -161,6 +161,7 @@ suite('Go Extension Tests With Gopls', function () {
 					assert.ok(item.command, `${uri}:${name}: expected command associated with ${item.label}, found none`);
 				}
 			}
-		}
+		});
+		await Promise.all(promises);
 	});
 });


### PR DESCRIPTION
I'm not sure why this failure (https://github.com/golang/vscode-go/runs/691533100?check_suite_focus=true) happened, to be honest, as I thought the completion tests should run synchronously. In any case, changing them to be able to run async should have no effect and matches the test above.