### PR TITLE
test/gopls: use settings.json instead of vscode extension API

### DIFF
--- a/test/gopls/extension.test.ts
+++ b/test/gopls/extension.test.ts
@@ -44,11 +44,6 @@ class Env {
 	}
 
 	public async setup() {
-		const wscfg = vscode.workspace.getConfiguration('go');
-		if (!wscfg.get('useLanguageServer')) {
-			wscfg.update('useLanguageServer', true, vscode.ConfigurationTarget.Workspace);
-		}
-
 		await this.reset();
 		await this.extension.activate();
 		await sleep(2000);  // allow extension host + gopls to start.
@@ -60,7 +55,7 @@ class Env {
 			// needed to keep the empty directory in vcs.
 			await fs.readdir(this.workspaceDir).then((files) => {
 				return Promise.all(
-					files.filter((filename) => filename !== '.gitignore').map((file) => {
+					files.filter((filename) => filename !== '.gitignore' && filename !== '.vscode').map((file) => {
 						fs.remove(path.resolve(this.workspaceDir, file));
 					}));
 			});
@@ -90,7 +85,7 @@ async function sleep(ms: number) {
 }
 
 suite('Go Extension Tests With Gopls', function () {
-	this.timeout(1000000);
+	this.timeout(300000);
 	const projectDir = path.join(__dirname, '..', '..', '..');
 	const env = new Env(projectDir);
 
@@ -162,5 +157,6 @@ suite('Go Extension Tests With Gopls', function () {
 				}
 			}
 		}
+
 	});
 });

--- a/test/gopls/testfixtures/src/workspace/.gitignore
+++ b/test/gopls/testfixtures/src/workspace/.gitignore
@@ -1,2 +1,3 @@
-*
+/*
 !.gitignore
+!.vscode/

--- a/test/gopls/testfixtures/src/workspace/.vscode/settings.json
+++ b/test/gopls/testfixtures/src/workspace/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+	"go.useLanguageServer": true,
+	"go.languageServerFlags": ["-rpc.trace", "serve"]
+}

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -16,7 +16,11 @@ async function main() {
 		const extensionTestsPath = path.resolve(__dirname, './integration/index');
 
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath });
+		await runTests({
+			extensionDevelopmentPath,
+			extensionTestsPath,
+			launchArgs: ['--disable-extensions'],  // disable all other extensions
+		});
 	} catch (err) {
 		console.error('Failed to run integration tests' + err);
 		failed = true;


### PR DESCRIPTION
Config update notification delivery is unpredictable and causes spurious
language server restarts.

Use the workspace vscode settings.json file so the vscode instance for testing
can pick up the necessary config as soon as it's activated.

Updates golang/vscode-go#79.

Change-Id: I0c05a415b0773ddfa75ba3cd9c328a4a3a75188c