### PR TITLE
src/goTest.ts: support running an individual subtest

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,11 @@
         "description": "Runs a unit test at the cursor."
       },
       {
+        "command": "go.subtest.cursor",
+        "title": "Go: Subtest At Cursor",
+        "description": "Runs a sub test at the cursor."
+      },
+      {
         "command": "go.benchmark.cursor",
         "title": "Go: Benchmark Function At Cursor",
         "description": "Runs a benchmark at the cursor."

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -37,7 +37,7 @@ import { playgroundCommand } from './goPlayground';
 import { GoReferencesCodeLensProvider } from './goReferencesCodelens';
 import { GoRunTestCodeLensProvider } from './goRunTestCodelens';
 import { outputChannel, showHideStatus } from './goStatus';
-import { testAtCursor, testCurrentFile, testCurrentPackage, testPrevious, testWorkspace } from './goTest';
+import { subTestAtCursor, testAtCursor, testCurrentFile, testCurrentPackage, testPrevious, testWorkspace } from './goTest';
 import { getConfiguredTools } from './goTools';
 import { vetCode } from './goVet';
 import {
@@ -269,6 +269,13 @@ export function activate(ctx: vscode.ExtensionContext): void {
 		vscode.commands.registerCommand('go.test.cursor', (args) => {
 			const goConfig = getGoConfig();
 			testAtCursor(goConfig, 'test', args);
+		})
+	);
+
+	ctx.subscriptions.push(
+		vscode.commands.registerCommand('go.subtest.cursor', (args) => {
+			const goConfig = getGoConfig();
+			subTestAtCursor(goConfig, 'test', args);
 		})
 	);
 

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -463,7 +463,11 @@ function targetArgs(testconfig: TestConfig): Array<string> {
 			// in running all the test methods, but one of them should call testify's `suite.Run(...)`
 			// which will result in the correct thing to happen
 			if (testFunctions.length > 0) {
-				params = params.concat(['-run', util.format('^(%s)$', testFunctions.join('|'))]);
+				if (testFunctions.length === 1) {
+					params = params.concat(['-run', util.format('^%s$', testFunctions.pop())]);
+				} else {
+					params = params.concat(['-run', util.format('^(%s)$', testFunctions.join('|'))]);
+				}
 			}
 			if (testifyMethods.length > 0) {
 				params = params.concat(['-testify.m', util.format('^(%s)$', testifyMethods.join('|'))]);


### PR DESCRIPTION
Similar to 'Test function at cursor', this allows running a test by placing
the cursor inside the test function or on the t.Run call. It will search
back from the current cursor position within the current outer test
function for a line that contains t.Run. If a subtest is found, an
appropriate call to runTestAtCursor is constructed and the test is
executed by existing go test functionality.

This is a port of https://github.com/microsoft/vscode-go/pull/3199