### PR TITLE
.github/workflows: use npm ci instead of npm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
          go-version: '1.14'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       
       - name: Compile
         run: npm run vscode:prepublish
@@ -86,7 +86,7 @@ jobs:
           node-version: '10.x'
 
       - name: Install Dependencies
-        run: 'npm install --frozen-lockfile'
+        run: 'npm ci'
         shell: bash
 
       - name: Lint check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
          go-version: '1.14'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Install Go tools (Modules mode)
         run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 dist: bionic
 
 go:
-  - 1.12.x
   - 1.13.x
   - 1.14.x
   - tip
@@ -29,7 +28,7 @@ before_install:
     fi
 
 install:
-  - TRAVIS_NODE_VERSION="8";
+  - TRAVIS_NODE_VERSION="12";
   # Clear out whatever version of NVM Travis has as it is old.
   - rm -rf ~/.nvm;
     # Grab NVM.
@@ -40,7 +39,7 @@ install:
     # Install the desired version of Node
   - source ~/.nvm/nvm.sh;
   - nvm install $TRAVIS_NODE_VERSION;
-  - npm install
+  - npm ci
   - npm run vscode:prepublish
   - go get -u -v github.com/acroca/go-symbols
   - go get -u -v github.com/cweill/gotests/...


### PR DESCRIPTION
npm install does not have `--frozen-lock` flag. (that's from yarn?)

Also, update .travis.yml
 - set node version to 12 which is recommended, and
 - remove go1.12 which is broken (update golang/vscode#66)

We are not using travis currently but for users who enabled it
from their forked repos, this is useful.
