### PR TITLE
src/goLanguageServer: improve handling of invalid or pre-release vers…

### DIFF
--- a/test/gopls/update.test.ts
+++ b/test/gopls/update.test.ts
@@ -4,67 +4,83 @@
  *--------------------------------------------------------*/
 
 import * as assert from 'assert';
+import moment = require('moment');
 import semver = require('semver');
 import sinon = require('sinon');
-import lsp = require('../../src/goLanguageServer');
+import * as lsp from '../../src/goLanguageServer';
 import { getTool, Tool } from '../../src/goTools';
 
 suite('gopls update tests', () => {
 	test('prompt for update', async () => {
 		const tool = getTool('gopls');
+
+		const toSemver = (v: string) => semver.coerce(v, {includePrerelease: true, loose: true});
+
+		// Fake data stubbed functions will serve.
+		const latestVersion = toSemver('0.4.1');
+		const latestVersionTimestamp = moment('2020-05-13', 'YYYY-MM-DD');
+		const latestPrereleaseVersion = toSemver('0.4.2-pre1');
+		const latestPrereleaseVersionTimestamp = moment('2020-05-20', 'YYYY-MM-DD');
+
+		// name, usersVersion, acceptPrerelease, want
 		const testCases: [string, string, boolean, semver.SemVer][] = [
-			['outdated, tagged', 'v0.3.1', false, tool.latestVersion],
-			['outdated, tagged (pre-release)', '0.3.1', true, tool.latestPrereleaseVersion],
-			['up-to-date, tagged', 'v0.4.0', false, null],
-			['up-to-date tagged (pre-release)', 'v0.4.0', true, tool.latestPrereleaseVersion],
+			['outdated, tagged', 'v0.3.1', false, latestVersion],
+			['outdated, tagged (pre-release)', '0.3.1', true, latestPrereleaseVersion],
+			['up-to-date, tagged', latestVersion.format(), false, null],
+			['up-to-date tagged (pre-release)', 'v0.4.0', true, latestPrereleaseVersion],
 			['developer version', '(devel)', false, null],
 			['developer version (pre-release)', '(devel)', true, null],
-			['nonsense version', 'nosuchversion', false, null],
-			['nonsense version (pre-release)', 'nosuchversion', true, null],
+			['nonsense version', 'nosuchversion', false, latestVersion],
+			['nonsense version (pre-release)', 'nosuchversion', true, latestPrereleaseVersion],
 			[
 				'latest pre-release',
-				'v0.4.1-pre1 h1:w6e4AmFe6sDSVrgaRkf4WqLyVAlByUrr9QM5xH7z1e4=',
+				'v0.4.2-pre1',
 				false, null,
 			],
 			[
 				'latest pre-release (pre-release)',
-				'v0.4.1-pre1 h1:w6e4AmFe6sDSVrgaRkf4WqLyVAlByUrr9QM5xH7z1e4=',
+				'v0.4.2-pre1',
 				true, null,
 			],
 			[
 				'outdated pre-release version',
-				'v0.3.1-pre1 h1:pBnJjmdcHy5AiRJleOWaakxFHykf8uXzSZKQMd0EA0Q=',
-				false, tool.latestVersion,
+				'v0.3.1-pre1',
+				false, latestVersion,
 			],
 			[
 				'outdated pre-release version (pre-release)',
-				'v0.3.1-pre1 h1:pBnJjmdcHy5AiRJleOWaakxFHykf8uXzSZKQMd0EA0Q=',
-				true, tool.latestPrereleaseVersion,
+				'v0.3.1-pre1',
+				true, latestPrereleaseVersion,
 			],
 			[
-				'recent pseudoversion after pre-release',
-				'v0.0.0-20200509030707-2212a7e161a5 h1:0gSpZ0Z2URJoo3oilGRq9ViMLDTlmNSDCyeZNHHrvd4=',
+				'recent pseudoversion after pre-release, 2020-05-20',
+				'v0.0.0-20200521000000-2212a7e161a5',
 				false, null,
 			],
 			[
-				'recent pseudoversion before pre-release',
-				'v0.0.0-20200501030707-2212a7e161a5 h1:0gSpZ0Z2URJoo3oilGRq9ViMLDTlmNSDCyeZNHHrvd4=',
+				'recent pseudoversion before pre-release, 2020-05-20',
+				'v0.0.0-20200515000000-2212a7e161a5',
 				false, null,
+			],
+			[
+				'recent pseudoversion after pre-release (pre-release)',
+				'v0.0.0-20200521000000-2212a7e161a5',
+				true, null,
 			],
 			[
 				'recent pseudoversion before pre-release (pre-release)',
-				'v0.0.0-20200501030707-2212a7e161a5 h1:0gSpZ0Z2URJoo3oilGRq9ViMLDTlmNSDCyeZNHHrvd4=',
-				true, tool.latestPrereleaseVersion,
+				'v0.0.0-20200515000000-2212a7e161a5',
+				true, latestPrereleaseVersion,
 			],
 			[
 				'outdated pseudoversion',
-				'v0.0.0-20200309030707-2212a7e161a5 h1:0gSpZ0Z2URJoo3oilGRq9ViMLDTlmNSDCyeZNHHrvd4=',
-				false, tool.latestVersion,
+				'v0.0.0-20200309030707-2212a7e161a5',
+				false, latestVersion,
 			],
 			[
 				'outdated pseudoversion (pre-release)',
-				'v0.0.0-20200309030707-2212a7e161a5 h1:0gSpZ0Z2URJoo3oilGRq9ViMLDTlmNSDCyeZNHHrvd4=',
-				true, tool.latestPrereleaseVersion,
+				'v0.0.0-20200309030707-2212a7e161a5',
+				true, latestPrereleaseVersion,
 			],
 		];
 		for (const [name, usersVersion, acceptPrerelease, want] of testCases) {
@@ -73,20 +89,20 @@ suite('gopls update tests', () => {
 			});
 			sinon.replace(lsp, 'getLatestGoplsVersion', async () => {
 				if (acceptPrerelease) {
-					return tool.latestPrereleaseVersion;
+					return latestPrereleaseVersion;
 				}
-				return tool.latestVersion;
+				return latestVersion;
 			});
 			sinon.replace(lsp, 'getTimestampForVersion', async (_: Tool, version: semver.SemVer) => {
-				if (version === tool.latestVersion) {
-					return tool.latestVersionTimestamp;
+				if (version === latestVersion) {
+					return latestVersionTimestamp;
 				}
-				if (version === tool.latestPrereleaseVersion) {
-					return tool.latestPrereleaseVersionTimestamp;
+				if (version === latestPrereleaseVersion) {
+					return latestPrereleaseVersionTimestamp;
 				}
 			});
 			const got = await lsp.shouldUpdateLanguageServer(tool, 'bad/path/to/gopls', true);
-			assert.equal(got, want, `${name}: failed`);
+			assert.deepEqual(got, want, `${name}: failed (got: '${got}' ${typeof got} want: '${want}' ${typeof want})`);
 			sinon.restore();
 		}
 	});


### PR DESCRIPTION
…ion strings

If getLocalGoplsVersion is completely busted and returns a nonsense value as
user's version, the later call to semver.lt with it can cause an exception.
Prevent it. Also, semver.lt does not handle comparison with a prerelease version
string correctly by itself. Avoid the issue by passing a correctly parsed
semver object instead.

Also, fix the gopls update tests by making the functions in goLanguageServers
really stubbable by making them function variables.

Previously,

export async function getLatestGoplsVersion(...) {  // to stub
}

export function shouldUpdateLanguageServer(...) {
  ...
  getLatestGoplsVersion(...)
  ...
}

This makes the getLatestGoplsVersion is captured in the exported
shouldUpdateLanguageServer closure. Later we attempt to stub getLatestGoplsVersion
with sinon, but it is too late.

This CL changes the above to

export const getLatestGoplsVersion = async (...) => { ... }

That makes shouldUpdateLanguageServer use the version of function we later configure.

Also, made the test not sensitive to the data in allToolsInformation (goTools.ts).
We will keep changing the latest release/prerelease versions, so depending on
them is not desirable.

Changed some of usersVersion in the test data. We are stubbing
getLocalGoplsVersion, that's supposed to return the part of the version string
without the hash part.

Update golang/vscode-go#37