### PR TITLE
package.json: change gopath/goroot/toolsGopath machine-overridable

### DIFF
--- a/package.json
+++ b/package.json
@@ -879,13 +879,13 @@
           ],
           "default": null,
           "description": "Specify GOPATH here to override the one that is set as environment variable. The inferred GOPATH from workspace root overrides this, if go.inferGopath is set to true.",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "go.toolsGopath": {
           "type": "string",
           "default": "",
           "description": "Location to install the Go tools that the extension depends on if you don't want them in your GOPATH.",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "go.goroot": {
           "type": [
@@ -894,7 +894,7 @@
           ],
           "default": null,
           "description": "Specifies the GOROOT to use when no environment variable is set.",
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "go.testOnSave": {
           "type": "boolean",


### PR DESCRIPTION
By setting them machine-overridable, client user values can be
ignored in remote settings and the remote side can pick up the right
value.

I think go.alternateTools should be machine-overridable as well
but will get to it next time.

Manually tested by

1) setting go.gopath in user settings, vsce package,
connecting to the remote host, sideloading vsix (do it after connecting,
so the remote host can pick up the vsix), and checking the GOPATH
with "Go: Current GOPATH" and also, by reinstalling all tools.

2) setting go.gopath in workspace settings and checking it's still doable.

Fixes microsoft/vscode-go#2981
Updates microsoft/vscode-go#2576

Change-Id: I3390355d186280c13353d210adb51edfa3858032