### PR TITLE
src/debugAdapter: suppress error pop-up for failed watch expression evaluation

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1592,9 +1592,9 @@ export class GoDebugSession extends LoggingDebugSession {
 				// are continiously reevaluated in the Watch panel, which
 				// already displays errors.
 				if (args.context === 'watch') {
-					dest = null
+					dest = null;
 				} else {
-					dest = ErrorDestination.User
+					dest = ErrorDestination.User;
 				}
 				this.sendErrorResponse(response, 2009, 'Unable to eval expression: "{e}"', {
 					e: err.toString()

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -15,6 +15,7 @@ import kill = require('tree-kill');
 import * as util from 'util';
 import {
 	DebugSession,
+	ErrorDestination,
 	Handles,
 	InitializedEvent,
 	logger,
@@ -26,8 +27,7 @@ import {
 	StackFrame,
 	StoppedEvent,
 	TerminatedEvent,
-	Thread,
-	ErrorDestination
+	Thread
 } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import {

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -26,7 +26,8 @@ import {
 	StackFrame,
 	StoppedEvent,
 	TerminatedEvent,
-	Thread
+	Thread,
+	ErrorDestination
 } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import {
@@ -1586,9 +1587,18 @@ export class GoDebugSession extends LoggingDebugSession {
 				log('EvaluateResponse');
 			},
 			(err) => {
+				let dest: ErrorDestination;
+				// No need to repeatedly show the error pop-up when expressions
+				// are continiously reevaluated in the Watch panel, which
+				// already displays errors.
+				if (args.context === 'watch') {
+					dest = null
+				} else {
+					dest = ErrorDestination.User
+				}
 				this.sendErrorResponse(response, 2009, 'Unable to eval expression: "{e}"', {
 					e: err.toString()
-				});
+				}, dest);
 			}
 		);
 	}


### PR DESCRIPTION
Watch expressions are repeated over and over again while the program is running, pausing, continuing, etc, and the result is always displayed and continuously refreshed under WATCH. Unlike other types of evaluations (e.g. in REPL, where one expression is evaluated at a time, and the error can be buried among logging messages), there is no advantage to also showing the same error in a pop-up box.

Fixes #143