### PR TITLE
Update testing.md

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,6 +23,12 @@ The Docker container used for testing is defined in [`build/cloudbuild.container
 GCB project members can manually trigger a build and test their local changes. Follow the [GCB instructions](https://cloud.google.com/cloud-build/docs/running-builds/start-build-manually) to set up the environment and tools, and then run:
 
 ```bash
+gcloud config set project vscode-go
+```
+
+This sets the project that commands will be run against. Next, run:
+
+```bash
 gcloud builds submit --config=build/cloudbuild.yaml
 ```
 


### PR DESCRIPTION
Add setting project ID to documentation

Before you can run gcloud commands you need to make sure the project ID is set, which was not specified in the docs before.