### PR TITLE
src/debugAdapter: adds error handling for remote connections

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -600,6 +600,7 @@ export class Delve {
 						}
 						return resolve(conn);
 					});
+					client.on('error', reject);
 				}, 200);
 			}
 

--- a/typings/json-rpc2.d.ts
+++ b/typings/json-rpc2.d.ts
@@ -6,5 +6,6 @@ declare module "json-rpc2" {
 	export class Client {
 		static $create(port: number, addr: string): Client;
 		connectSocket(callback: (err: Error, conn: RPCConnection) => void): void;
+		on(handler: 'error', callback: (err: Error) => void): void;
 	}
 }


### PR DESCRIPTION
json-rpc2 module doesn't catch all the errors in its callback. If a remote connection fails to be established, it won't call the callback for errors. So the connection will hang. There are no future plans to handle the error case through the callback: json-rpc2: pocesar/node-jsonrpc2#53. Node.js handles errors in a similar way: https://nodejs.org/api/net.html#net_socket_connect. Errors won't be exposed through the callback, only through the error listener. 

Fixes golang/vscode-go#215
