### PR TITLE
ci: add windows and mac test and run lint at the end in cloudbuild

### DIFF
--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -1,0 +1,82 @@
+name: Long Tests
+
+on: [push]
+  branches-ignore:
+    - 'latest'
+    - 'upstream'
+
+jobs:
+  build:
+    name: ${{ matrix.os }} ${{ matrix.version }}
+    runs-on: ${{ matrix.os }}
+    
+    # Not containing 'SKIP CI' in the commit message AND
+    # (Either non-Windows OR triggered on 'push' (if triggered by 'pull_request', github.base_ref is not empty)
+    if: "!contains(github.event.head_commit.message, 'SKIP CI')"
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        version: ['stable']
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+         go-version: '1.14'
+
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Compile
+        run: npm run vscode:prepublish
+
+      - name: Install Go tools (Modules mode)
+        run: |
+            go version
+            go get github.com/acroca/go-symbols
+            go get github.com/davidrjenni/reftools/cmd/fillstruct
+            go get github.com/haya14busa/goplay/cmd/goplay
+            go get github.com/mdempsky/gocode
+            go get github.com/sqs/goreturns
+            go get github.com/uudashr/gopkgs/v2/cmd/gopkgs
+            go get github.com/zmb3/gogetdoc
+            go get golang.org/x/lint/golint
+            go get golang.org/x/tools/cmd/gorename
+            go get golang.org/x/tools/gopls
+        env:
+          GO111MODULE: on   
+          
+      - name: Install Go tools (GOPATH mode)
+        run: |
+          go version
+          go get github.com/cweill/gotests/...
+          go get github.com/rogpeppe/godef
+          go get github.com/ramya-rao-a/go-outline
+            # Because some tests depend on the source code checked in GOPATH. TODO: FIX THEM.
+        env:
+          GO111MODULE: off
+      
+      - name: Run unit tests
+        run: npm run unit-test
+        continue-on-error: true
+        
+      - name: Run tests
+        uses: GabrielBB/xvfb-action@v1.0
+        with:
+          run: npm run test
+        env:
+          CODE_VERSION: ${{ matrix.version }}
+      
+      - name: Lint check
+        run: npm run lint
+        if: ${{ matrix.os }} == 'ubuntu-latest'

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -1,12 +1,14 @@
-name: build
+name: Smoke Tests
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
     name: ${{ matrix.os }} ${{ matrix.version }}
     runs-on: ${{ matrix.os }}
     
+    # Not containing 'SKIP CI' in the commit message AND
+    # (Either non-Windows OR triggered on 'push' (if triggered by 'pull_request', github.base_ref is not empty)
     if: "!contains(github.event.head_commit.message, 'SKIP CI')"
     timeout-minutes: 20
     strategy:
@@ -38,25 +40,25 @@ jobs:
       - name: Install Go tools (Modules mode)
         run: |
             go version
-            go get github.com/acroca/go-symbols \
-               github.com/davidrjenni/reftools/cmd/fillstruct \
-               github.com/haya14busa/goplay/cmd/goplay \
-               github.com/mdempsky/gocode \
-               github.com/sqs/goreturns \
-               github.com/uudashr/gopkgs/v2/cmd/gopkgs \
-               github.com/zmb3/gogetdoc \
-               golang.org/x/lint/golint \
-               golang.org/x/tools/cmd/gorename \
-               golang.org/x/tools/gopls
+            go get github.com/acroca/go-symbols
+            go get github.com/davidrjenni/reftools/cmd/fillstruct
+            go get github.com/haya14busa/goplay/cmd/goplay
+            go get github.com/mdempsky/gocode
+            go get github.com/sqs/goreturns
+            go get github.com/uudashr/gopkgs/v2/cmd/gopkgs
+            go get github.com/zmb3/gogetdoc
+            go get golang.org/x/lint/golint
+            go get golang.org/x/tools/cmd/gorename
+            go get golang.org/x/tools/gopls
         env:
           GO111MODULE: on   
           
       - name: Install Go tools (GOPATH mode)
         run: |
           go version
-          go get github.com/cweill/gotests/... \
-            github.com/rogpeppe/godef \
-            github.com/ramya-rao-a/go-outline
+          go get github.com/cweill/gotests/...
+          go get github.com/rogpeppe/godef
+          go get github.com/ramya-rao-a/go-outline
             # Because some tests depend on the source code checked in GOPATH. TODO: FIX THEM.
         env:
           GO111MODULE: off
@@ -72,22 +74,6 @@ jobs:
         env:
           CODE_VERSION: ${{ matrix.version }}
 
-  eslint:
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'SKIP CI')"
-
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v1
-
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '10.x'
-
-      - name: Install Dependencies
-        run: 'npm ci'
-        shell: bash
-
       - name: Lint check
         run: npm run lint
+        if: ${{ matrix.os }} == 'ubuntu-latest'

--- a/build/all.bash
+++ b/build/all.bash
@@ -45,9 +45,9 @@ run_test() {
   echo "**** Run test ****"
   npm ci
   npm run compile
-  npm run lint
   npm run unit-test
   npm test --silent
+  npm run lint
 }
 
 run_test_in_docker() {


### PR DESCRIPTION
Run lint as part of the usual build/test job instead of running it as a separate job.
But place it at the end so we can run tests even when fixing lint is necessary.

Separate ci.yml to test-smoke.yml (Smoke Tests) and test-long.yml (Long Tests).
Long Tests run on windows and mac as well, while Smoke Tests run only on linux.
(I removed mac and windows from Smoke Tests because our tests fail on windows currently).

Long Tests will be triggered on 'push', and
Smoke Tests will run on every 'pull_request'.

Updates #208