### PR TITLE
debug: make launch configuration name consistent with docs and other launch.json 

### DIFF
--- a/src/debugAdapter/.vscode/launch.json
+++ b/src/debugAdapter/.vscode/launch.json
@@ -2,7 +2,7 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"name": "debug-debugger",
+			"name": "Launch as server",
 			"type": "node",
 			"request": "launch",
 			"program": "${workspaceFolder}/../../out/src/debugAdapter/goDebug.js",


### PR DESCRIPTION
The documentation for launching a debug adapter (https://github.com/golang/vscode-go/blob/master/docs/debug-adapter.md) says "Choose the Launch as server" debug configuration.

However, the launch.json in the debugAdapter dir names this configuration "debug-debugger".

Fix the configuration name to be consistent with documentation, and with other launch.json files (the root launch.json also has this configuration named "Launch as server").

