### PR TITLE
test: increase timeout and skip gopls update check in testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -64,7 +64,6 @@
 				"--disable-extensions",
 				"--extensionDevelopmentPath=${workspaceFolder}",
 				"--extensionTestsPath=${workspaceFolder}/out/test/gopls/index",
-				"--user-data-dir", "${workspaceFolder}/test/gopls/testfixtures/src/workspace",
 				"--timeout", "999999",
 				"${workspaceFolder}/test/gopls/testfixtures/src/workspace"  // gopls requires a workspace to work with.
 			],

--- a/test/gopls/testfixtures/src/workspace/.vscode/settings.json
+++ b/test/gopls/testfixtures/src/workspace/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
 	"go.useLanguageServer": true,
-	"go.languageServerFlags": ["-rpc.trace", "serve"]
+	"go.languageServerFlags": ["-rpc.trace", "serve"],
+	"go.useGoProxyToCheckForToolUpdates": false,
 }

--- a/test/integration/install.test.ts
+++ b/test/integration/install.test.ts
@@ -16,7 +16,9 @@ import { installTools } from '../../src/goInstallTools';
 import { getTool, getToolAtVersion } from '../../src/goTools';
 import { getBinPath, getGoVersion, rmdirRecursive } from '../../src/util';
 
-suite('Installation Tests', () => {
+suite('Installation Tests', function () {
+	this.timeout(10000);
+
 	test('install tools', async () => {
 		const goVersion = await getGoVersion();
 		const testCases: string[][] = [
@@ -33,6 +35,7 @@ suite('Installation Tests', () => {
 
 			const sandbox = sinon.createSandbox();
 			const utils = require('../../src/util');
+
 			const toolsGopathStub = sandbox.stub(utils, 'getToolsGopath').returns(tmpToolsGopath);
 			const goConfig = Object.create(vscode.workspace.getConfiguration('go'), {
 				toolsEnvVars: {


### PR DESCRIPTION
installation tests require multiple fs operations, and 2s may be
too short to complete everything on time. Allow more time.

And disable the gopls update check in gopls testing. That shortens
the time to bring up the gopls server.

Also remove the hack to start the test with a clean user profile
(--user-data-dir). That doesn't seem to work but interferes with
picking up the workspace settings, which I do not understand why.

Updates golang/vscode-go#169
Updates golang/vscode-go#43
Updates microsoft/vscode#97995
