### PR TITLE
ci: fix github action yml syntax error for test-long

### DIFF
--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -1,9 +1,10 @@
 name: Long Tests
 
-on: [push]
-  branches-ignore:
-    - 'latest'
-    - 'upstream'
+on:
+  push:
+    branches-ignore:
+      - 'latest'
+      - 'upstream'
 
 jobs:
   build:


### PR DESCRIPTION
I missed the error because this workflow gets triggered only when the PR is merged.

The result run from my github action is available in https://github.com/hyangah/vscode-go/actions/runs/138926703.

(Windows test is really slow and we have test failures to investigate.)