### PR TITLE
src/goInstallTools.ts: fix PATH adjustment when a different go is chosen

### DIFF
--- a/src/goEnvironmentStatus.ts
+++ b/src/goEnvironmentStatus.ts
@@ -18,20 +18,15 @@ let goEnvStatusbarItem: vscode.StatusBarItem;
  * Initialize the status bar item with current Go binary
  */
 export async function initGoStatusBar() {
-	goEnvStatusbarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 50);
-
-	// make goroot default to go.goroot and fallback on $PATH
-	const goroot = await getActiveGoRoot();
-	if (!goroot) {
-		// TODO: prompt user to install Go
-		vscode.window.showErrorMessage('No Go command could be found.');
+	if (!goEnvStatusbarItem) {
+		goEnvStatusbarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 50);
 	}
-
 	// set Go version and command
 	const version = await getGoVersion();
+
+	hideGoStatusBar();
 	goEnvStatusbarItem.text = formatGoVersion(version.format());
 	goEnvStatusbarItem.command = 'go.environment.choose';
-
 	showGoStatusBar();
 }
 

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -18,7 +18,7 @@ import {
 import { GoDebugConfigurationProvider } from './goDebugConfiguration';
 import { extractFunction, extractVariable } from './goDoctor';
 import { toolExecutionEnvironment } from './goEnv';
-import { chooseGoEnvironment, initGoStatusBar } from './goEnvironmentStatus';
+import { chooseGoEnvironment } from './goEnvironmentStatus';
 import { runFillStruct } from './goFillStruct';
 import * as goGenerateTests from './goGenerateTests';
 import { goGetPackage } from './goGetPackage';
@@ -167,11 +167,6 @@ export function activate(ctx: vscode.ExtensionContext): void {
 			);
 		})
 	);
-	showHideStatus(vscode.window.activeTextEditor);
-
-	// show the go environment status bar item
-	initGoStatusBar();
-
 	const testCodeLensProvider = new GoRunTestCodeLensProvider();
 	const referencesCodeLensProvider = new GoReferencesCodeLensProvider();
 
@@ -407,8 +402,14 @@ export function activate(ctx: vscode.ExtensionContext): void {
 				return;
 			}
 			const updatedGoConfig = getGoConfig();
-			updateGoVarsFromConfig();
 
+			if (e.affectsConfiguration('go.goroot') ||
+				e.affectsConfiguration('go.alternateTools') ||
+				e.affectsConfiguration('go.gopath') ||
+				e.affectsConfiguration('go.toolsEnvVars') ||
+				e.affectsConfiguration('go.testEnvFile')) {
+					updateGoVarsFromConfig();
+			}
 			// If there was a change in "toolsGopath" setting, then clear cache for go tools
 			if (getToolsGopath() !== getToolsGopath(false)) {
 				clearCacheForTools();

--- a/src/goPath.ts
+++ b/src/goPath.ts
@@ -12,6 +12,7 @@
 import fs = require('fs');
 import os = require('os');
 import path = require('path');
+import { getGoConfig } from './util';
 
 let binPathCache: { [bin: string]: string } = {};
 
@@ -34,14 +35,16 @@ export function getBinPathFromEnvVar(toolName: string, envVarValue: string, appe
 export function getBinPathWithPreferredGopath(
 	toolName: string,
 	preferredGopaths: string[],
-	alternateTool?: string
+	alternateTool?: string,
+	useCache = true,
 ) {
 	if (alternateTool && path.isAbsolute(alternateTool) && executableFileExists(alternateTool)) {
 		binPathCache[toolName] = alternateTool;
 		return alternateTool;
 	}
 
-	if (binPathCache[toolName]) {
+	// FIXIT: this cache needs to be invalidated when go.goroot or go.alternateTool is changed.
+	if (useCache && binPathCache[toolName]) {
 		return binPathCache[toolName];
 	}
 
@@ -64,7 +67,7 @@ export function getBinPathWithPreferredGopath(
 	}
 
 	// Check GOROOT (go, gofmt, godoc would be found here)
-	const pathFromGoRoot = getBinPathFromEnvVar(binname, getCurrentGoRoot(), true);
+	const pathFromGoRoot = getBinPathFromEnvVar(binname, getGoConfig().get('goroot') || getCurrentGoRoot(), true);
 	if (pathFromGoRoot) {
 		binPathCache[toolName] = pathFromGoRoot;
 		return pathFromGoRoot;

--- a/test/fixtures/testhelpers/fakego.go
+++ b/test/fixtures/testhelpers/fakego.go
@@ -1,0 +1,47 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Licensed under the MIT License.
+// See LICENSE in the project root for license information.
+
+// This is a helper used to fake a go binary.
+// It currently fakes `go env` and `go version` commands.
+// For `go env`, it returns FAKEGOROOT for 'GOROOT', and an empty string for others.
+// For `go version`, it returns FAKEGOVERSION or a default dev version string.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	args := os.Args
+
+	if len(args) <= 1 {
+		return
+	}
+	switch args[1] {
+	case "env":
+		fakeEnv(args[2:])
+	case "version":
+		fakeVersion()
+	default:
+		fmt.Fprintf(os.Stderr, "not implemented")
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func fakeEnv(args []string) {
+	for _, a := range args {
+		fmt.Println(os.Getenv("FAKE" + a))
+	}
+}
+
+func fakeVersion() {
+	ver := os.Getenv("FAKEGOVERSION")
+	if ver != "" {
+		fmt.Println(ver)
+		return
+	}
+	fmt.Println("go version devel +a07e2819 Thu Jun 18 20:58:26 2020 +0000 darwin/amd64")
+}

--- a/test/integration/statusbar.test.ts
+++ b/test/integration/statusbar.test.ts
@@ -5,14 +5,22 @@
  *--------------------------------------------------------*/
 
 import * as assert from 'assert';
+import cp = require('child_process');
+import fs = require('fs');
 import { describe, it } from 'mocha';
-
-import { disposeGoStatusBar, formatGoVersion, getGoEnvironmentStatusbarItem, initGoStatusBar } from '../../src/goEnvironmentStatus';
-import { getGoVersion } from '../../src/util';
+import os = require('os');
+import path = require('path');
+import sinon = require('sinon');
+import util = require('util');
+import { WorkspaceConfiguration } from 'vscode';
+import { disposeGoStatusBar, formatGoVersion, getGoEnvironmentStatusbarItem } from '../../src/goEnvironmentStatus';
+import { updateGoVarsFromConfig } from '../../src/goInstallTools';
+import { getCurrentGoRoot } from '../../src/goPath';
+import ourutil = require('../../src/util');
 
 describe('#initGoStatusBar()', function () {
-	this.beforeAll(() => {
-		initGoStatusBar();
+	this.beforeAll(async () => {
+		await updateGoVarsFromConfig();  // should initialize the status bar.
 	});
 
 	this.afterAll(() => {
@@ -23,13 +31,119 @@ describe('#initGoStatusBar()', function () {
 		assert.notEqual(getGoEnvironmentStatusbarItem(), undefined);
 	});
 
-	it('should create a status bar item with a label matching go.goroot version', async () =>  {
-		const version = await getGoVersion();
+	it('should create a status bar item with a label matching go.goroot version', async () => {
+		const version = await ourutil.getGoVersion();
 		const versionLabel = formatGoVersion(version.format());
 		assert.equal(
 			getGoEnvironmentStatusbarItem().text,
 			versionLabel,
 			'goroot version does not match status bar item text'
 		);
+	});
+});
+
+describe('#updateGoVarsFromConfig()', function () {
+	this.timeout(10000);
+
+	let defaultGoConfig: WorkspaceConfiguration | undefined;
+	let tmpRoot: string | undefined;
+	let tmpRootBin: string | undefined;
+	let sandbox: sinon.SinonSandbox | undefined;
+
+	this.beforeAll(async () => {
+		defaultGoConfig = ourutil.getGoConfig();
+
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rootchangetest'));
+		tmpRootBin = path.join(tmpRoot, 'bin');
+
+		// build a fake go binary and place it in tmpRootBin.
+		fs.mkdirSync(tmpRootBin);
+
+		const fixtureSourcePath = path.join(__dirname, '..', '..', '..', 'test', 'fixtures', 'testhelpers');
+		const execFile = util.promisify(cp.execFile);
+		const goRuntimePath = ourutil.getBinPath('go');
+		const { stdout, stderr } = await execFile(
+			goRuntimePath, ['build', '-o', path.join(tmpRootBin, 'go'), path.join(fixtureSourcePath, 'fakego.go')]);
+		if (stderr) {
+			assert.fail(`failed to build the fake go binary required for testing: ${stderr}`);
+		}
+	});
+
+	this.afterAll(() => {
+		ourutil.rmdirRecursive(tmpRoot);
+	});
+
+	this.beforeEach(() => {
+		sandbox = sinon.createSandbox();
+	});
+
+	this.afterEach(() => {
+		sandbox.restore();
+	});
+
+	function pathEnvVar(): string[] {
+		let paths = [] as string[];
+		if (process.env.hasOwnProperty('PATH')) {
+			paths = process.env['PATH'].split(path.delimiter);
+		} else if (process.platform === 'win32' && process.env.hasOwnProperty('Path')) {
+			paths = process.env['Path'].split(path.delimiter);
+		}
+		return paths;
+	}
+
+	it('should have a sensible goroot with the default setting', async () => {
+		await updateGoVarsFromConfig();
+
+		const b = getGoEnvironmentStatusbarItem();
+		assert.ok(b.text.startsWith('Go'), `go env statusbar item = ${b.text}, want "Go..."`);
+		assert.equal(pathEnvVar()[0], [path.join(getCurrentGoRoot(), 'bin')],
+			`the first element in PATH must match the current GOROOT/bin`);
+	});
+
+	it('should recognize the adjusted goroot using go.goroot', async () => {
+		// stub geteGoConfig to return "go.goroot": tmpRoot.
+		const getGoConfigStub = sandbox.stub(ourutil, 'getGoConfig').returns({
+			get: (s: string) => {
+				if (s === 'goroot') { return tmpRoot; }
+				return defaultGoConfig.get(s);
+			},
+		} as WorkspaceConfiguration);
+
+		// adjust the fake go binary's behavior.
+		process.env['FAKEGOROOT'] = tmpRoot;
+		process.env['FAKEGOVERSION'] = 'go version go2.0.0 darwin/amd64';
+
+		await updateGoVarsFromConfig();
+
+		sandbox.assert.calledWith(getGoConfigStub);
+		assert.equal((await ourutil.getGoVersion()).format(), '2.0.0');
+		assert.equal(getGoEnvironmentStatusbarItem().text, 'Go 2.0.0');
+		assert.equal(pathEnvVar()[0], [path.join(getCurrentGoRoot(), 'bin')],
+			`the first element in PATH must match the current GOROOT/bin`);
+	});
+
+	it('should recognize the adjusted goroot using go.alternateTools', async () => {
+		// "go.alternateTools" : {"go": "go3"}
+		fs.copyFileSync(path.join(tmpRootBin, 'go'), path.join(tmpRootBin, 'go3'));
+
+		const getGoConfigStub = sandbox.stub(ourutil, 'getGoConfig').returns({
+			get: (s: string) => {
+				if (s === 'alternateTools') {
+					return { go: path.join(tmpRootBin, 'go3') };
+				}
+				return defaultGoConfig.get(s);
+			},
+		} as WorkspaceConfiguration);
+
+		process.env['FAKEGOROOT'] = tmpRoot;
+		process.env['FAKEGOVERSION'] = 'go version go3.0.0 darwin/amd64';
+
+		await updateGoVarsFromConfig();
+
+		sandbox.assert.calledWith(getGoConfigStub);
+		assert.equal((await ourutil.getGoVersion()).format(), '3.0.0');
+		assert.equal(getGoEnvironmentStatusbarItem().text, 'Go 3.0.0');
+		assert.equal(pathEnvVar()[0], [path.join(getCurrentGoRoot(), 'bin')],
+			`the first element in PATH must match the current GOROOT/bin`);
 	});
 });


### PR DESCRIPTION
With commits d93a0ae and a5e40ca (microsoft/vscode-go#3152), we tried to
include the go binary's path to the PATH (Path on windows) in order to ensure
all underlying go tools (gofmt, cgo, gopls, ...) that simply invoke 'go'
can find the matching go binary by searching the PATH.

We found that trick does not work when users specifies a different go version
using go.alternateTools and the specified binary is not named 'go'.
For example, golang.org provides an easy way to install extra versions of Go
https://golang.org/doc/install#extra_versions through a wrapper, whose
name includes the version. Users who take this approach should be able to
configure to pick up the chosen version with

```
  "go.alternateTools": {
     "go": "/Users/username/go/bin/go1.13.11"
  }
```

Previously, we just added /Users/username/go/bin (the go binary directory name)
to PATH. Because there is no 'go' binary in this directory, the underlying
tools failed to pick the right go tool.

In this CL, we instead use the GOROOT (found from go env call) and add
GOROOT/bin to the PATH.

In this CL

- We also arrange to call updateGoVarsFromConfig only when the relevant
configs are changed (onDidChangeConfiguration setup in goMain.ts).
Previously, this was called almost on every file save events if the repository
has a workspace setting file (.vscode/setting.json).

- We also changed initGoStatusBar to be called after the goroot is updated.
That eliminates an extra call path (initGoStatusBar -> ... -> updateGoVarsFromConfig,
and also, reflects goroot changes correctly when the configuration is updated.

Updates golang/vscode-go#146
Updates golang/vscode-go#26