### PR TITLE
src/testUtils: fix lost previous test function name

### DIFF
--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -464,7 +464,7 @@ function targetArgs(testconfig: TestConfig): Array<string> {
 			// which will result in the correct thing to happen
 			if (testFunctions.length > 0) {
 				if (testFunctions.length === 1) {
-					params = params.concat(['-run', util.format('^%s$', testFunctions.pop())]);
+					params = params.concat(['-run', util.format('^%s$', testFunctions[0])]);
 				} else {
 					params = params.concat(['-run', util.format('^(%s)$', testFunctions.join('|'))]);
 				}


### PR DESCRIPTION
targetArgs mutates the testconfig.functions, that's an alias of lastTestConfig.
A better fix is probably to avoid the alias at the first place and store a complete
clone as the lastTestConfig, but I don't know how efficiently that can be done.

But anyway, mutating the configuration on the fly is not desirable. So, avoid it.

Fixes golang/vscode-go#269