### PR TITLE
debug: fix to prevents multiple debug sessions launching

### DIFF
--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -8,6 +8,7 @@
 
 import * as path from 'path';
 import vscode = require('vscode');
+import { debug } from 'vscode';
 import { GoDlvDapDebugSession } from './debugAdapter2/goDlvDebug';
 import { browsePackages } from './goBrowsePackage';
 import { buildCode } from './goBuild';
@@ -303,6 +304,10 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 	ctx.subscriptions.push(
 		vscode.commands.registerCommand('go.debug.cursor', (args) => {
+			if (debug.activeDebugSession) {
+				vscode.window.showErrorMessage('Debug session has already been started.');
+				return;
+			}
 			const goConfig = getGoConfig();
 			testAtCursor(goConfig, 'debug', args);
 		})

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -8,7 +8,6 @@
 
 import * as path from 'path';
 import vscode = require('vscode');
-import { debug } from 'vscode';
 import { GoDlvDapDebugSession } from './debugAdapter2/goDlvDebug';
 import { browsePackages } from './goBrowsePackage';
 import { buildCode } from './goBuild';
@@ -304,7 +303,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
 
 	ctx.subscriptions.push(
 		vscode.commands.registerCommand('go.debug.cursor', (args) => {
-			if (debug.activeDebugSession) {
+			if (vscode.debug.activeDebugSession) {
 				vscode.window.showErrorMessage('Debug session has already been started.');
 				return;
 			}


### PR DESCRIPTION
Fixes golang/vscode-go#109

Clicking 'debug test' twice will launch multiple instances.
Fixed to show an error message if debug session already exists.