### PR TITLE
package.json: make `additionalProperties` false for object type settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1394,6 +1394,7 @@
               "description": "Gutter style to indicate covered code."
             }
           },
+          "additionalProperties": false,
           "default": {
             "type": "highlight",
             "coveredHighlightColor": "rgba(64,128,128,0.5)",
@@ -1532,6 +1533,7 @@
               "description": "If true, the language server will provide clickable Godoc links for import statements."
             }
           },
+          "additionalProperties": false,
           "default": {
             "diagnostics": true,
             "documentLink": true
@@ -1579,6 +1581,7 @@
               "description": "If true, enables code lens for running and debugging tests"
             }
           },
+          "additionalProperties": false,
           "default": {
             "references": false,
             "runtest": true
@@ -1614,6 +1617,7 @@
               "description": "Transformation rule used by Go: Add Tags command to add tags"
             }
           },
+          "additionalProperties": false,
           "default": {
             "tags": "json",
             "options": "json=omitempty",
@@ -1637,6 +1641,7 @@
               "description": "The number of milliseconds to delay before execution. Resets with each keystroke."
             }
           },
+          "additionalProperties": false,
           "default": {
             "enabled": false,
             "delay": 500
@@ -1663,6 +1668,7 @@
               "description": "Comma separated tag=options pairs to be used by Go: Remove Tags command"
             }
           },
+          "additionalProperties": false,
           "default": {
             "tags": "",
             "options": "",
@@ -1691,6 +1697,7 @@
             },
             "description": "The flags configured here will be passed through to command `goplay`"
           },
+          "additionalProperties": false,
           "default": {
             "openbrowser": true,
             "share": true,
@@ -1771,6 +1778,7 @@
               "description": "If true, adds command to debug the test under the cursor to the editor context menu"
             }
           },
+          "additionalProperties": false,
           "default": {
             "toggleTestFile": true,
             "addTags": true,
@@ -1904,7 +1912,8 @@
               "default": "guru",
               "description": "Alternate tool to use instead of the guru binary or alternate path to use for the guru binary."
             }
-          }
+          },
+          "additionalProperties": false
         }
       }
     },


### PR DESCRIPTION
When I'm working on making simple non-nested object type settings editable from the settings GUI in vscode (microsoft/vscode#99635), and I think that setting `additionalProperties` to `false` for the objects that don't expect more properties would be great!

As per microsoft/vscode#101810, vscode (v1.48) will hide the "Add item" button if and only if `additionalProperties` is `false` and all known properties are present. 