### PR TITLE
debug:  remove unnecessary settings from package.json of debugAdapter2

### DIFF
--- a/package.json
+++ b/package.json
@@ -846,11 +846,10 @@
                 "enum": [
                   "auto",
                   "debug",
-                  "remote",
                   "test",
                   "exec"
                 ],
-                "description": "One of 'auto', 'debug', 'remote', 'test', 'exec'.",
+                "description": "One of 'auto', 'debug', 'test', 'exec'.",
                 "default": "auto"
               },
               "stopOnEntry": {

--- a/package.json
+++ b/package.json
@@ -1113,15 +1113,6 @@
                   "maxStructFields": -1
                 }
               },
-              "apiVersion": {
-                "type": "number",
-                "enum": [
-                  1,
-                  2
-                ],
-                "description": "Delve Api Version to use. Default value is 2.",
-                "default": 2
-              },
               "stackTraceDepth": {
                 "type": "number",
                 "description": "Maximum depth of stack trace collected from Delve",

--- a/package.json
+++ b/package.json
@@ -948,8 +948,7 @@
                   "gdbwire",
                   "lldbout",
                   "debuglineerr",
-                  "dap",
-                  "rpc"
+                  "dap"
                 ],
                 "description": "Comma separated list of components that should produce debug output.",
                 "default": "debugger"
@@ -991,15 +990,6 @@
                   "maxArrayValues": 64,
                   "maxStructFields": -1
                 }
-              },
-              "apiVersion": {
-                "type": "number",
-                "enum": [
-                  1,
-                  2
-                ],
-                "description": "Delve Api Version to use. Default value is 2.",
-                "default": 2
               },
               "stackTraceDepth": {
                 "type": "number",


### PR DESCRIPTION
These were copied over from the original package.json debug configuration in golang/vscode-go#267

Fixes golang/vscode-go#271