### PR TITLE
debug: more robust wait for server to listen to socket

### DIFF
--- a/src/debugAdapter2/dapClient.ts
+++ b/src/debugAdapter2/dapClient.ts
@@ -28,6 +28,11 @@ export class DAPClient extends EventEmitter {
 		super();
 	}
 
+	public send(req: any): void {
+		const json = JSON.stringify(req);
+		this.outputStream.write(`Content-Length: ${Buffer.byteLength(json, 'utf8')}\r\n\r\n${json}`, 'utf8');
+	}
+
 	// Connect this client to a server, which is represented by read and write
 	// streams. Before this method is called, send() won't work and not messages
 	// from the server will be delivered.
@@ -37,11 +42,6 @@ export class DAPClient extends EventEmitter {
 		readable.on('data', (data: Buffer) => {
 			this.handleData(data);
 		});
-	}
-
-	public send(req: any): void {
-		const json = JSON.stringify(req);
-		this.outputStream.write(`Content-Length: ${Buffer.byteLength(json, 'utf8')}\r\n\r\n${json}`, 'utf8');
 	}
 
 	// Implements parsing of the DAP protocol. We cannot use ProtocolClient

--- a/src/debugAdapter2/dapClient.ts
+++ b/src/debugAdapter2/dapClient.ts
@@ -34,7 +34,7 @@ export class DAPClient extends EventEmitter {
 	}
 
 	// Connect this client to a server, which is represented by read and write
-	// streams. Before this method is called, send() won't work and not messages
+	// streams. Before this method is called, send() won't work and no messages
 	// from the server will be delivered.
 	protected connect(readable: stream.Readable, writable: stream.Writable): void {
 		this.outputStream = writable;

--- a/src/debugAdapter2/dapClient.ts
+++ b/src/debugAdapter2/dapClient.ts
@@ -28,17 +28,20 @@ export class DAPClient extends EventEmitter {
 		super();
 	}
 
-	public send(req: any): void {
-		const json = JSON.stringify(req);
-		this.outputStream.write(`Content-Length: ${Buffer.byteLength(json, 'utf8')}\r\n\r\n${json}`, 'utf8');
-	}
-
+	// Connect this client to a server, which is represented by read and write
+	// streams. Before this method is called, send() won't work and not messages
+	// from the server will be delivered.
 	protected connect(readable: stream.Readable, writable: stream.Writable): void {
 		this.outputStream = writable;
 
 		readable.on('data', (data: Buffer) => {
 			this.handleData(data);
 		});
+	}
+
+	public send(req: any): void {
+		const json = JSON.stringify(req);
+		this.outputStream.write(`Content-Length: ${Buffer.byteLength(json, 'utf8')}\r\n\r\n${json}`, 'utf8');
 	}
 
 	// Implements parsing of the DAP protocol. We cannot use ProtocolClient

--- a/src/debugAdapter2/goDlvDebug.ts
+++ b/src/debugAdapter2/goDlvDebug.ts
@@ -618,7 +618,7 @@ class DelveClient extends DAPClient {
 
 	// Connect this client to the server. The server is expected to be listening
 	// on host:port.
-	private connectSocketToServer(port: number, host:string) {
+	private connectSocketToServer(port: number, host: string) {
 		// Add a slight delay to ensure that Delve started up the server.
 		setTimeout(() => {
 			const socket = net.createConnection(

--- a/src/debugAdapter2/goDlvDebug.ts
+++ b/src/debugAdapter2/goDlvDebug.ts
@@ -544,6 +544,7 @@ export class GoDlvDapDebugSession extends LoggingDebugSession {
 //    'close' (rc):           delve exited with return code rc
 class DelveClient extends DAPClient {
 	private debugProcess: ChildProcess;
+	private serverStarted: boolean = false;
 
 	constructor(launchArgs: LaunchRequestArguments) {
 		super();
@@ -594,6 +595,11 @@ class DelveClient extends DAPClient {
 		this.debugProcess.stdout.on('data', (chunk) => {
 			const str = chunk.toString();
 			this.emit('stdout', str);
+
+			if (!this.serverStarted) {
+				this.serverStarted = true;
+				this.connectSocketToServer(launchArgs.port, launchArgs.host);
+			}
 		});
 
 		this.debugProcess.on('close', (rc) => {
@@ -608,13 +614,16 @@ class DelveClient extends DAPClient {
 		this.debugProcess.on('error', (err) => {
 			throw err;
 		});
+	}
 
-		// Give the Delve DAP server some time to start up before connecting.
-		// TODO: do this in a more robust way.
+	// Connect this client to the server. The server is expected to be listening
+	// on host:port.
+	private connectSocketToServer(port: number, host:string) {
+		// Add a slight delay to ensure that Delve started up the server.
 		setTimeout(() => {
 			const socket = net.createConnection(
-				launchArgs.port,
-				launchArgs.host,
+				port,
+				host,
 				() => {
 					this.connect(socket, socket);
 					this.emit('connected');
@@ -623,6 +632,6 @@ class DelveClient extends DAPClient {
 			socket.on('error', (err) => {
 				throw err;
 			});
-		}, 100);
+		}, 200);
 	}
 }


### PR DESCRIPTION
Take the waiting code from the existing adapter - try to connect after server emits to stdout. Also add comment in dapClient.ts for clarity.

Updates golang/vscode-go#23
Follow up on golang/vscode-go#267
