### PR TITLE
.github/workflows: stop if unit tests fail

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -70,7 +70,6 @@ jobs:
 
       - name: Run unit tests
         run: npm run unit-test
-        continue-on-error: true
 
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1.0

--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -69,7 +69,6 @@ jobs:
       
       - name: Run unit tests
         run: npm run unit-test
-        continue-on-error: true
         
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1.0

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -65,7 +65,6 @@ jobs:
       
       - name: Run unit tests
         run: npm run unit-test
-        continue-on-error: true
         
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1.0


### PR DESCRIPTION
continue-on-error was set true to keep testing, but
it obviously makes the test failure difficult to notice.
Fail hard.

Fixes golang/vscode-go#289
