### PR TITLE
debug: properly use dirname of launchArgs.program for debugging

### DIFF
--- a/src/debugAdapter2/goDlvDebug.ts
+++ b/src/debugAdapter2/goDlvDebug.ts
@@ -606,9 +606,6 @@ export class GoDlvDapDebugSession extends LoggingDebugSession {
 			throw new Error('launchNoDebug requires "debug" mode');
 		}
 		const {program, dirname, programIsDirectory} = parseProgramArgSync(launchArgs);
-		if (!program) {
-			throw new Error('The program attribute is missing in the debug configuration in launch.json');
-		}
 		if (!programIsDirectory && path.extname(program) !== '.go') {
 			throw new Error('The program attribute must be a directory or .go file in debug mode');
 		}
@@ -779,12 +776,15 @@ class DelveClient extends DAPClient {
 function parseProgramArgSync(launchArgs: LaunchRequestArguments
 ): { program: string, dirname: string, programIsDirectory: boolean } {
 	const program = launchArgs.program;
+	if (!program) {
+		throw new Error('The program attribute is missing in the debug configuration in launch.json');
+	}
 	let programIsDirectory = false;
 	try {
-		programIsDirectory = fs.lstatSync(launchArgs.program).isDirectory();
+		programIsDirectory = fs.lstatSync(program).isDirectory();
 	} catch (e) {
 		throw new Error('The program attribute must point to valid directory, .go file or executable.');
 	}
-	const dirname = programIsDirectory ? launchArgs.program : path.dirname(launchArgs.program);
+	const dirname = programIsDirectory ? program : path.dirname(program);
 	return {program, dirname, programIsDirectory};
 }

--- a/src/debugAdapter2/goDlvDebug.ts
+++ b/src/debugAdapter2/goDlvDebug.ts
@@ -767,6 +767,11 @@ class DelveClient extends DAPClient {
 //             it's already a directory),
 //    programIsDirectory: is the program a directory?
 // }
+//
+// The program argument is taken as-is from launchArgs. If the program path
+// is relative, dirname will also be relative. If the program path is absolute,
+// dirname will also be absolute.
+//
 // Throws an exception in case args.program is not a valid file or directory.
 // This function can block because it calls a blocking fs function.
 function parseProgramArgSync(launchArgs: LaunchRequestArguments

--- a/src/debugAdapter2/goDlvDebug.ts
+++ b/src/debugAdapter2/goDlvDebug.ts
@@ -781,9 +781,9 @@ function parseProgramArgSync(launchArgs: LaunchRequestArguments
 	} catch (e) {
 		throw new Error('The program attribute must point to valid directory, .go file or executable.');
 	}
-	const dirname = programIsDirectory ? program : path.dirname(program);
 	if (!programIsDirectory && path.extname(program) !== '.go') {
 		throw new Error('The program attribute must be a directory or .go file in debug mode');
 	}
+	const dirname = programIsDirectory ? program : path.dirname(program);
 	return {program, dirname, programIsDirectory};
 }

--- a/src/debugAdapter2/goDlvDebug.ts
+++ b/src/debugAdapter2/goDlvDebug.ts
@@ -606,10 +606,6 @@ export class GoDlvDapDebugSession extends LoggingDebugSession {
 			throw new Error('launchNoDebug requires "debug" mode');
 		}
 		const {program, dirname, programIsDirectory} = parseProgramArgSync(launchArgs);
-		if (!programIsDirectory && path.extname(program) !== '.go') {
-			throw new Error('The program attribute must be a directory or .go file in debug mode');
-		}
-
 		const goRunArgs = ['run'];
 		if (launchArgs.buildFlags) {
 			goRunArgs.push(launchArgs.buildFlags);
@@ -786,5 +782,8 @@ function parseProgramArgSync(launchArgs: LaunchRequestArguments
 		throw new Error('The program attribute must point to valid directory, .go file or executable.');
 	}
 	const dirname = programIsDirectory ? program : path.dirname(program);
+	if (!programIsDirectory && path.extname(program) !== '.go') {
+		throw new Error('The program attribute must be a directory or .go file in debug mode');
+	}
 	return {program, dirname, programIsDirectory};
 }


### PR DESCRIPTION
Also refactors the analysis of launchArgs.program since it's now used in two
places.
