### PR TITLE
src/goLint.ts: fixes a golangci-lint integration issue

### DIFF
--- a/src/goLint.ts
+++ b/src/goLint.ts
@@ -125,6 +125,11 @@ export function goLint(
 			// Explicit override in case .golangci.yml calls for a format we don't understand
 			args.push('--out-format=colored-line-number');
 		}
+		if (args.indexOf('--issues-exit-code=') === -1) {
+			// adds an explicit no-error-code return argument, to avoid npm error
+			// message detection logic. See golang/vscode-go/issues/411
+			args.push('--issues-exit-code=0');
+		}
 	}
 
 	if (scope === 'workspace' && currentWorkspace) {


### PR DESCRIPTION
golangci-lint outputs the analysis results in stdout, but sometimes uses stderr to print non-critical error or warning messages. For example, when `nolintlint` is enabled, some issues are reported in stderr. That is not a lint error, but outputting the log messages in stderr breaks the current assumption `runTool` in `util.ts` makes. 

As a low-risk workaround, this CL forces `golangci-lint` to always exit with 0 using its `--issues-exit-code`. That will prevent `runTool` from thinking the tool failed and bailing out early.

Fixes golang/vscode-go#411.