### PR TITLE
Allow usage of unsupported formatter and linter tools with new settings

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -102,7 +102,7 @@ Predefined snippets for quick coding. These snippets will appear as completion s
 
 Format code and organize imports, either manually or on save. The code is formatted by the [`gofmt`](tools.md#formatting) tool, which is the standard for Go code. Imports are added automatically to your file via the [`goimports`](tools.md#formatting) tool, which is also an industry standard. By default, this extension also uses the [`goreturns`](tools.md#formatting) tool, which automatically fills in default return values for functions.
 
-The behavior of the formatter can be configured via the [`"go.formatTool"`](settings.md#go.formatTool) tool setting. The [troubleshooting guide](troubleshooting.md#formatting) gives more details and explains how to [disable formatting](troubleshooting.md#disable-formatting) entirely.
+The behavior of the formatter can be configured via the [`"go.formatTool"`](settings.md#go.formatTool) tool setting. This setting supports some tools by default but, if a different formatter tool is to be used, it can be configured via the [`"go.formatAlternateTool"`](settings.md#go.formatAlternateTool) setting. The [troubleshooting guide](troubleshooting.md#formatting) gives more details and explains how to [disable formatting](troubleshooting.md#disable-formatting) entirely.
 
 #### Add import
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -160,6 +160,8 @@ Much like vet errors, lint errors can also be shown on save. This behavior is co
 
 The default lint tool is the one provided by the `go` command: `go lint`. However, custom lint tools can be easily used instead by configuring the [`"go.lintTool"`](settings.md#go.lintTool) setting. [`staticcheck`], [`golangci-lint`], and [`revive`] are supported.
 
+Unsupported tools can be configured via the [`"go.lintAlternateTool"`](settings.md#go.lintAlternateTool) setting.
+
 For a complete overview of linter options, see the [documentation for diagnostic tools](tools.md#diagnostics).
 
 ## Run and test in the editor

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -288,6 +288,12 @@ Allowed Values:`[golint golangci-lint revive staticcheck]`
 
 Default: `golint`
 
+### `go.lintAlternateTool`
+
+Alternate linter to use, overrides `go.lintTool`. Useful for unsupported linters, `go.lintFlags` might be required to parse it's output.
+
+Default: `<nil>`
+
 ### `go.liveErrors`
 
 Use gotype on the file currently being edited and report any semantic or syntactic errors found after configured delay.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -180,9 +180,15 @@ Flags to pass to format tool (e.g. ["-s"])
 
 Not applicable when using the language server. Choosing 'goimports' or 'goreturns' will add missing imports and remove unused imports.
 
-Allowed Values:`[gofmt goimports goreturns goformat]`
+Allowed Values: `[gofmt goimports goreturns goformat]`
 
 Default: `goreturns`
+
+### `go.formatAlternateTool`
+
+Not applicable when using the language server. Alternate formatter to use, overrides `go.formatTool`. Useful for unsupported formatters, `go.formatFlags` might be required to parse it's output.
+
+Default: `<nil>`
 
 ### `go.generateTestsFlags`
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -130,7 +130,7 @@ Configure this via the [`"go.docsTool"`](settings.md#go.docsTool) setting.
 
 Formatting tools are used by the [formatting and import organization](features.md#format-and-organize-imports) features.
 
-[`goreturns`] is used by default. It formats the file according to the industry standard [`gofmt`] style, organizes imports, and fills in default return values for functions. Other tools can be used for formatting instead; this can be configured with the [`"go.go.formatTool"`](settings.md#formatTool) setting.
+[`goreturns`] is used by default. It formats the file according to the industry standard [`gofmt`] style, organizes imports, and fills in default return values for functions. Other tools can be used for formatting instead; this can be configured with the [`"go.formatTool"`](settings.md#formatTool) setting.
 
 **NOTE: [`goreturns`] does not have support for Go modules, so we recommend using [`goimports`] or [`gopls`] instead.**
 
@@ -139,6 +139,8 @@ Other format tool options include:
 * [`goimports`], which applies the default `gofmt` style and organizes imports, but without the behavior of filling in default return values
 * [`gofmt`] only formats the file, without import organization or filling in return values
 * [`goformat`] is a configurable version of [`gofmt`]
+
+Unsupported formatters by the extension can also be used with the [`"go.formatAlternateTool"`](settings.md#go.formatAlternateTool) setting.
 
 ### Diagnostics
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -158,6 +158,8 @@ Other lint tools can be used instead of [`golint`] by configuring the [`"go.lint
 * [`golangci-lint`]: This tool combines a number of existing lint tools, including [staticcheck](#staticcheck), into one interface.
 * [`revive`]: This tool is an enhancement on top of [`golint`], and it provides additional checks.
 
+Other unsupported lint tools can be used by configuring the [`"go.lintAlternateTool"`](settings.md#go.lintAlternateTool) setting. As they are not officially supported, it might be required to set the [`"go.lintAlternateTool"`](settings.md#go.lintAlternateTool) setting to understand the tool's output.
+
 You can use the [`"go.lintFlags"`](settings.md#go.lintFlags) setting to further configure your linter of choice. Most linters can be configured via special configuration files, but you may still need to pass these command-line flags. The configuration documentation for each supported linter is listed here:
 
 * [`staticcheck`](https://staticcheck.io/docs/#configuration)

--- a/package.json
+++ b/package.json
@@ -1243,6 +1243,15 @@
             "goformat"
           ]
         },
+        "go.formatAlternateTool": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Not applicable when using the language server. Alternate formatter to use, overrides `go.formatTool`. Useful for unsupported formatters, `go.formatFlags` might be required to parse it's output.",
+          "scope": "resource"
+        },
         "go.formatFlags": {
           "type": "array",
           "items": {

--- a/package.json
+++ b/package.json
@@ -1202,6 +1202,15 @@
             "staticcheck"
           ]
         },
+        "go.lintAlternateTool": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Alternate linter to use, overrides `go.lintTool`. Useful for unsupported linters, `go.lintFlags` might be required to parse it's output.",
+          "scope": "resource"
+        },
         "go.lintFlags": {
           "type": "array",
           "items": {

--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -25,22 +25,27 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 
 		const filename = document.fileName;
 		const goConfig = getGoConfig(document.uri);
-		const formatTool = goConfig['formatTool'] || 'goreturns';
+
+		let formatTool = goConfig['formatAlternateTool'] || null;
 		const formatFlags = goConfig['formatFlags'].slice() || [];
 
-		// We ignore the -w flag that updates file on disk because that would break undo feature
-		if (formatFlags.indexOf('-w') > -1) {
-			formatFlags.splice(formatFlags.indexOf('-w'), 1);
-		}
+		if (formatTool === null) {
+			formatTool = goConfig['formatTool'] || 'goreturns';
 
-		// Fix for https://github.com/Microsoft/vscode-go/issues/613 and https://github.com/Microsoft/vscode-go/issues/630
-		if (formatTool === 'goimports' || formatTool === 'goreturns') {
-			formatFlags.push('-srcdir', filename);
-		}
+			// We ignore the -w flag that updates file on disk because that would break undo feature
+			if (formatFlags.indexOf('-w') > -1) {
+				formatFlags.splice(formatFlags.indexOf('-w'), 1);
+			}
 
-		// Since goformat supports the style flag, set tabsize if user has not passed any flags
-		if (formatTool === 'goformat' && formatFlags.length === 0 && options.insertSpaces) {
-			formatFlags.push('-style=indent=' + options.tabSize);
+			// Fix for https://github.com/Microsoft/vscode-go/issues/613 and https://github.com/Microsoft/vscode-go/issues/630
+			if (formatTool === 'goimports' || formatTool === 'goreturns') {
+				formatFlags.push('-srcdir', filename);
+			}
+
+			// Since goformat supports the style flag, set tabsize if user has not passed any flags
+			if (formatTool === 'goformat' && formatFlags.length === 0 && options.insertSpaces) {
+				formatFlags.push('-style=indent=' + options.tabSize);
+			}
 		}
 
 		return this.runFormatter(formatTool, formatFlags, document, token).then(


### PR DESCRIPTION
Updates golang/vscode-go#587

Add go.formatAlternateTool and go.lintAlternateTool to enable other tools rather than the supported ones.
These settings override the values of go.formatTool and go.lintTool and bypasses every check or change
of the tool invocation flags, leaving them untouched.