### PR TITLE
debugAdapter: fix a bug where we are not sending back configuration done response

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -878,6 +878,8 @@ export class GoDebugSession extends LoggingDebugSession {
 			this.debugState = await this.delve.getDebugState();
 			if (!this.debugState.Running) {
 				this.continueRequest(<DebugProtocol.ContinueResponse>response);
+			} else {
+				this.sendResponse(response);
 			}
 		}
 	}

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -876,10 +876,12 @@ export class GoDebugSession extends LoggingDebugSession {
 		} else {
 			this.debugState = await this.delve.getDebugState();
 			if (!this.debugState.Running) {
+				log('Changing DebugState from Halted to Running');
 				this.continue();
 			}
 		}
 		this.sendResponse(response);
+		log('ConfigurationDoneResponse', response);
 	}
 
 	/**

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1531,6 +1531,13 @@ export class GoDebugSession extends LoggingDebugSession {
 		});
 	}
 
+	protected continueRequest(response: DebugProtocol.ContinueResponse): void {
+		log('ContinueRequest');
+		this.continue();
+		this.sendResponse(response);
+		log('ContinueResponse');
+	}
+
 	protected nextRequest(response: DebugProtocol.NextResponse): void {
 		log('NextRequest');
 		this.delve.call<DebuggerState | CommandOut>('Command', [{ name: 'next' }], (err, out) => {

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -873,15 +873,13 @@ export class GoDebugSession extends LoggingDebugSession {
 		if (this.stopOnEntry) {
 			this.sendEvent(new StoppedEvent('entry', 1));
 			log('StoppedEvent("entry")');
-			this.sendResponse(response);
 		} else {
 			this.debugState = await this.delve.getDebugState();
 			if (!this.debugState.Running) {
-				this.continueRequest(<DebugProtocol.ContinueResponse>response);
-			} else {
-				this.sendResponse(response);
+				this.continue();
 			}
 		}
+		this.sendResponse(response);
 	}
 
 	/**
@@ -1529,13 +1527,6 @@ export class GoDebugSession extends LoggingDebugSession {
 			this.sendResponse(response);
 			log('VariablesResponse', JSON.stringify(variables, null, ' '));
 		});
-	}
-
-	protected continueRequest(response: DebugProtocol.ContinueResponse): void {
-		log('ContinueRequest');
-		this.continue();
-		this.sendResponse(response);
-		log('ContinueResponse');
 	}
 
 	protected nextRequest(response: DebugProtocol.NextResponse): void {


### PR DESCRIPTION
This change is to address this bug: https://github.com/eclipse-theia/theia/issues/8455. The Go extension is not able to continue past after hitting the breakpoint because `setConfigurationDoneRequest` is not sending back a response if the program is already running. This keeps Theia waiting for the response (which it never receives!).