### PR TITLE
src/goModules: exclude vendor paths from inferGopath disable mechanism

### DIFF
--- a/src/goModules.ts
+++ b/src/goModules.ts
@@ -65,7 +65,7 @@ export async function getModFolderPath(fileuri: vscode.Uri, isDir?: boolean): Pr
 		goModEnvResult = path.dirname(goModEnvResult);
 		const goConfig = getGoConfig(fileuri);
 
-		if (goConfig['inferGopath'] === true) {
+		if (goConfig['inferGopath'] === true && !fileuri.path.includes('/vendor/')) {
 			goConfig.update('inferGopath', false, vscode.ConfigurationTarget.WorkspaceFolder);
 			vscode.window.showInformationMessage(
 				'The "inferGopath" setting is disabled for this workspace because Go modules are being used.'


### PR DESCRIPTION
Go extension disables `go.inferGopath` when operating in the module-aware mode.
The extension heuristically determines whether it's in module-aware mode or not by
checking the presence of a `go.mod` file in the workspace. Vendored packages though
confuses this heuristics and can incorrectly conclude and disable the feature.
Exclude files from the vendor paths in this decision making.
  
Fixes golang/vscode-go#301