### PR TITLE
src/goModifytags: support gomodifytags's --template flag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,4 @@
 	},
 	"editor.insertSpaces": false,
 	"typescript.tsdk": "node_modules\\typescript\\lib",
-	"go.inferGopath": false,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,4 +11,5 @@
 	},
 	"editor.insertSpaces": false,
 	"typescript.tsdk": "node_modules\\typescript\\lib",
+	"go.inferGopath": false,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4420,7 +4420,7 @@
       }
     },
     "tree-kill": {
-      "version": "file:third_party/tree-kill",
+      "version": "file:https:/registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
     },
     "ts-loader": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4420,7 +4420,7 @@
       }
     },
     "tree-kill": {
-      "version": "file:https:/registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "version": "file:third_party/tree-kill",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
     },
     "ts-loader": {

--- a/package.json
+++ b/package.json
@@ -1693,7 +1693,8 @@
             "tags": "json",
             "options": "json=omitempty",
             "promptForTags": false,
-            "transform": "snakecase"
+            "transform": "snakecase",
+            "template": ""
           },
           "description": "Tags and options configured here will be used by the Add Tags command to add tags to struct fields. If promptForTags is true, then user will be prompted for tags and options. By default, json tags are added.",
           "scope": "resource"

--- a/src/goModifytags.ts
+++ b/src/goModifytags.ts
@@ -165,7 +165,7 @@ function runGomodifytags(args: string[]) {
 			promptForMissingTool('gomodifytags');
 			return;
 		}
-		if (err && (<any>err).code === 2 && args.indexOf("--template") > 0) {
+		if (err && (<any>err).code === 2 && args.indexOf('--template') > 0) {
 			vscode.window.showInformationMessage(`Cannot modify tags: you might be using a` +
 												`version that does not support --template`);
 			promptForUpdatingTool('gomodifytags');

--- a/src/goModifytags.ts
+++ b/src/goModifytags.ts
@@ -33,7 +33,8 @@ export function addTags(commandArgs: GoTagsConfig) {
 		return;
 	}
 
-	getTagsAndOptions(<GoTagsConfig>getGoConfig()['addTags'], commandArgs).then(([tags, options, transformValue, template]) => {
+	getTagsAndOptions(<GoTagsConfig>getGoConfig()['addTags'], commandArgs).then((
+		[tags, options, transformValue, template]) => {
 		if (!tags && !options) {
 			return;
 		}
@@ -118,7 +119,7 @@ function getTagsAndOptions(config: GoTagsConfig, commandArgs: GoTagsConfig): The
 	const transformValue: string =
 		commandArgs && commandArgs.hasOwnProperty('transform') ? commandArgs['transform'] : config['transform'];
 	const format: string =
-		commandArgs && commandArgs.hasOwnProperty('template') ? commandArgs['template']: config['template'];
+		commandArgs && commandArgs.hasOwnProperty('template') ? commandArgs['template'] : config['template'];
 
 	if (!promptForTags) {
 		return Promise.resolve([tags, options, transformValue, format]);

--- a/src/goModifytags.ts
+++ b/src/goModifytags.ts
@@ -24,6 +24,7 @@ interface GoTagsConfig {
 	tags: string;
 	options: string;
 	promptForTags: boolean;
+	template: string;
 }
 
 export function addTags(commandArgs: GoTagsConfig) {
@@ -32,7 +33,7 @@ export function addTags(commandArgs: GoTagsConfig) {
 		return;
 	}
 
-	getTagsAndOptions(<GoTagsConfig>getGoConfig()['addTags'], commandArgs).then(([tags, options, transformValue]) => {
+	getTagsAndOptions(<GoTagsConfig>getGoConfig()['addTags'], commandArgs).then(([tags, options, transformValue, template]) => {
 		if (!tags && !options) {
 			return;
 		}
@@ -47,6 +48,10 @@ export function addTags(commandArgs: GoTagsConfig) {
 		if (transformValue) {
 			args.push('--transform');
 			args.push(transformValue);
+		}
+		if (template) {
+			args.push('--template');
+			args.push(template);
 		}
 		runGomodifytags(args);
 	});
@@ -112,9 +117,11 @@ function getTagsAndOptions(config: GoTagsConfig, commandArgs: GoTagsConfig): The
 			: config['promptForTags'];
 	const transformValue: string =
 		commandArgs && commandArgs.hasOwnProperty('transform') ? commandArgs['transform'] : config['transform'];
+	const format: string =
+		commandArgs && commandArgs.hasOwnProperty('template') ? commandArgs['template']: config['template'];
 
 	if (!promptForTags) {
-		return Promise.resolve([tags, options, transformValue]);
+		return Promise.resolve([tags, options, transformValue, format]);
 	}
 
 	return vscode.window
@@ -135,7 +142,14 @@ function getTagsAndOptions(config: GoTagsConfig, commandArgs: GoTagsConfig): The
 							prompt: 'Enter transform value'
 						})
 						.then((transformOption) => {
-							return [inputTags, inputOptions, transformOption];
+							return vscode.window
+							.showInputBox({
+								value: format,
+								prompt: 'Enter template value'
+							})
+							.then((template) => {
+								return [inputTags, inputOptions, transformOption, template];
+							});
 						});
 				});
 		});

--- a/src/goModifytags.ts
+++ b/src/goModifytags.ts
@@ -8,7 +8,7 @@
 import cp = require('child_process');
 import vscode = require('vscode');
 import { toolExecutionEnvironment } from './goEnv';
-import { promptForMissingTool } from './goInstallTools';
+import { promptForMissingTool, promptForUpdatingTool } from './goInstallTools';
 import { byteOffsetAt, getBinPath, getFileArchive, getGoConfig } from './util';
 
 // Interface for the output from gomodifytags
@@ -163,6 +163,12 @@ function runGomodifytags(args: string[]) {
 	const p = cp.execFile(gomodifytags, args, { env: toolExecutionEnvironment() }, (err, stdout, stderr) => {
 		if (err && (<any>err).code === 'ENOENT') {
 			promptForMissingTool('gomodifytags');
+			return;
+		}
+		if (err && (<any>err).code === 2 && args.indexOf("--template") > 0) {
+			vscode.window.showInformationMessage(`Cannot modify tags: you might be using a` +
+												`version that does not support --template`);
+			promptForUpdatingTool('gomodifytags');
 			return;
 		}
 		if (err) {


### PR DESCRIPTION
Support gomodifytags 1.11.0 new --template feature

As of [1.11.0](https://github.com/fatih/gomodifytags/releases/tag/v1.11.0) there is a `--template` option in gomofidytags that allows to give a special formatting to the tags, this adds support to it.



