### PR TITLE
package.json: add missing transform variants for go.addTags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1689,7 +1689,10 @@
               "type": "string",
               "enum": [
                 "snakecase",
-                "camelcase"
+                "camelcase",
+                "lispcase",
+                "pascalcase",
+                "keep"
               ],
               "default": "snakecase",
               "description": "Transformation rule used by Go: Add Tags command to add tags"


### PR DESCRIPTION
This simply allows in the settings.json or UI to use the missing 'lispcase', 'pascalcase' and 'keep'
transform options for the go.addTags command.

fixes golang/vscode-go#906