### PR TITLE
snippets: avoid using "var" as default name in snippets

### DIFF
--- a/snippets/go.json
+++ b/snippets/go.json
@@ -67,7 +67,7 @@
 		},
 		"for range statement": {
 			"prefix": "forr",
-			"body": "for ${1:_, }${2:var} := range ${3:var} {\n\t$0\n}",
+			"body": "for ${1:_, }${2:v} := range ${3:v} {\n\t$0\n}",
 			"description": "Snippet for a for range loop"
 		},
 		"channel declaration": {


### PR DESCRIPTION
"var" is a reserved keyword. Some snippets using "var" as the default name produce Error: "expected 1 expression"
Replace the usage with more general names like `v`

Fixes golang/vscode-go#969 