### PR TITLE
snippets: add snippet for type function declaration

### DIFF
--- a/snippets/go.json
+++ b/snippets/go.json
@@ -20,6 +20,11 @@
 			"body": "const (\n\t${1:name} = ${2:value}\n)",
 			"description": "Snippet for a constant block"
 		},
+		"type function declaration": {
+			"prefix": "tyf",
+			"body": "type ${1:name} func($3) $4",
+			"description": "Snippet for a type function declaration"
+		},
 		"type interface declaration": {
 			"prefix": "tyi",
 			"body": "type ${1:name} interface {\n\t$0\n}",


### PR DESCRIPTION
Add snippet with name `tyf` for type function declaration:
```
type name func() // snippet to fill
type Example func(string, int) error // example of filled snippet
```
Rationale - they are already:
- `tyi` - snippet for a type interface
- `tys` - snippet for a struct declaration

the only one missing is a snippet for type function declaration. It is quite common in Go to declare and use function types, so this new snippet makes a programmer's life easier