### PR TITLE
docs/gopls.md: remove the link of `gopls` settings block section

### DIFF
--- a/docs/gopls.md
+++ b/docs/gopls.md
@@ -11,7 +11,6 @@
   * [Automatic updates](#automatic-updates)
 * [Configuration](#configuration)
   * [Ignored settings](#ignored-settings)
-  * [`gopls` settings block](#gopls-settings-block)
 * [Troubleshooting](https://github.com/golang/tools/blob/master/gopls/doc/troubleshooting.md)
 * [Additional resources](#additional-resources)
 


### PR DESCRIPTION
It is removed in this cl [1].

[1]: https://go-review.googlesource.com/c/vscode-go/+/279419