### PR TITLE
package.json: add disableConcurrentTests setting

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -160,6 +160,11 @@ Default:
 	"showGlobalVariables" :	false,
 }
 ```
+### `go.disableConcurrentTests`
+
+If true, tests will not run concurrently. When a new test run is started, the previous will be cancelled.
+
+Default: `false`
 ### `go.docsTool`
 
 Pick 'godoc' or 'gogetdoc' to get documentation. Not applicable when using the language server.<br/>

--- a/package.json
+++ b/package.json
@@ -1322,6 +1322,12 @@
           "description": "The Go build tags to use for when running tests. If null, then buildTags will be used.",
           "scope": "resource"
         },
+        "go.disableConcurrentTests": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, tests will not run concurrently. When a new test run is started, the previous will be cancelled.",
+          "scope": "resource"
+        },
         "go.installDependenciesWhenBuilding": {
           "type": "boolean",
           "default": false,

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -263,6 +263,10 @@ export async function goTest(testconfig: TestConfig): Promise<boolean> {
 		outputChannel.clear();
 	}
 
+	if (!!testconfig.goConfig['disableConcurrentTests']) {
+		await cancelRunningTests();
+	}
+
 	if (!testconfig.background) {
 		outputChannel.show(true);
 	}


### PR DESCRIPTION
This change adds a `disableConcurrentTests` setting which when set to `true`, invokes the already existing helper `cancelRunningTests` before spawning a new test process. 

Fixes golang/vscode-go#1089