### PR TITLE
src/debugAdapter: disable stackTrace error pop-ups

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1454,7 +1454,9 @@ export class GoDebugSession extends LoggingDebugSession {
 					this.logDelveError(err, 'Failed to produce stacktrace');
 					return this.sendErrorResponse(response, 2004, 'Unable to produce stack trace: "{e}"', {
 						e: err.toString()
-					});
+					},
+					// Disable showUser pop-up since errors already show up under the CALL STACK pane
+					null);
 				}
 				const locations = this.delve.isApiV1 ? <DebugLocation[]>out : (<StacktraceOut>out).Locations;
 				log('locations', locations);

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1452,11 +1452,14 @@ export class GoDebugSession extends LoggingDebugSession {
 			async (err, out) => {
 				if (err) {
 					this.logDelveError(err, 'Failed to produce stacktrace');
-					return this.sendErrorResponse(response, 2004, 'Unable to produce stack trace: "{e}"', {
-						e: err.toString()
-					},
-					// Disable showUser pop-up since errors already show up under the CALL STACK pane
-					null);
+					return this.sendErrorResponse(
+						response,
+						2004,
+						'Unable to produce stack trace: "{e}"',
+						{ e: err.toString() },
+						// Disable showUser pop-up since errors already show up under the CALL STACK pane
+						null
+					);
 				}
 				const locations = this.delve.isApiV1 ? <DebugLocation[]>out : (<StacktraceOut>out).Locations;
 				log('locations', locations);


### PR DESCRIPTION
The errors already show up in the UI under CALL STACK, so the pop-ups just get in the way.

Updates golang/vscode-go#179 