### PR TITLE
src/goInstallTools: use go env -json to query go env vars

### DIFF
--- a/src/goEnv.ts
+++ b/src/goEnv.ts
@@ -63,7 +63,7 @@ export function toolExecutionEnvironment(uri?: vscode.Uri): NodeJS.Dict<string> 
 
 	// Remove json flag (-json or --json=<any>) from GOFLAGS because it will effect to result format of the execution
 	if (env['GOFLAGS'] && env['GOFLAGS'].includes('-json')) {
-		env['GOFLAGS'] = env['GOFLAGS'].replace(/-?-json[^\s]*\s*/g, '');
+		env['GOFLAGS'] = env['GOFLAGS'].replace(/(^|\s+)-?-json[^\s]*/g, '');
 		logVerbose(`removed -json from GOFLAGS: ${env['GOFLAGS']}`);
 	}
 	return env;

--- a/src/goEnv.ts
+++ b/src/goEnv.ts
@@ -8,6 +8,7 @@
 import vscode = require('vscode');
 import { getGoConfig } from './config';
 import { getCurrentGoPath, getToolsGopath, resolvePath } from './util';
+import { logVerbose } from './goLogging';
 
 // toolInstallationEnvironment returns the environment in which tools should
 // be installed. It always returns a new object.
@@ -58,6 +59,12 @@ export function toolExecutionEnvironment(uri?: vscode.Uri): NodeJS.Dict<string> 
 	const gopath = getCurrentGoPath(uri);
 	if (gopath) {
 		env['GOPATH'] = gopath;
+	}
+
+	// Remove json flag (-json or --json=<any>) from GOFLAGS because it will effect to result format of the execution
+	if (env['GOFLAGS'] && env['GOFLAGS'].includes('-json')) {
+		env['GOFLAGS'] = env['GOFLAGS'].replace(/-?-json[^\s]*\s*/g, '');
+		logVerbose(`removed -json from GOFLAGS: ${env['GOFLAGS']}`);
 	}
 	return env;
 }

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -441,6 +441,7 @@ export function updateGoVarsFromConfig(): Promise<void> {
 	return new Promise<void>((resolve, reject) => {
 		cp.execFile(
 			goRuntimePath,
+			// -json is supported since go1.9
 			['env', '-json', 'GOPATH', 'GOROOT', 'GOPROXY', 'GOBIN', 'GOMODCACHE'],
 			{ env: toolExecutionEnvironment(), cwd: getWorkspaceFolderPath() },
 			(err, stdout, stderr) => {

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -441,7 +441,7 @@ export function updateGoVarsFromConfig(): Promise<void> {
 	return new Promise<void>((resolve, reject) => {
 		cp.execFile(
 			goRuntimePath,
-			['env', 'GOPATH', 'GOROOT', 'GOPROXY', 'GOBIN', 'GOMODCACHE'],
+			['env', '-json', 'GOPATH', 'GOROOT', 'GOPROXY', 'GOBIN', 'GOMODCACHE'],
 			{ env: toolExecutionEnvironment(), cwd: getWorkspaceFolderPath() },
 			(err, stdout, stderr) => {
 				if (err) {
@@ -462,21 +462,15 @@ export function updateGoVarsFromConfig(): Promise<void> {
 					outputChannel.show();
 				}
 				logVerbose(`${goRuntimePath} env ...:\n${stdout}`);
-				const envOutput = stdout.split('\n');
-				if (!process.env['GOPATH'] && envOutput[0].trim()) {
-					process.env['GOPATH'] = envOutput[0].trim();
+				const envOutput = JSON.parse(stdout);
+				if (envOutput.GOROOT && envOutput.GOROOT.trim()) {
+					setCurrentGoRoot(envOutput.GOROOT.trim());
+					delete envOutput.GOROOT;
 				}
-				if (envOutput[1] && envOutput[1].trim()) {
-					setCurrentGoRoot(envOutput[1].trim());
-				}
-				if (!process.env['GOPROXY'] && envOutput[2] && envOutput[2].trim()) {
-					process.env['GOPROXY'] = envOutput[2].trim();
-				}
-				if (!process.env['GOBIN'] && envOutput[3] && envOutput[3].trim()) {
-					process.env['GOBIN'] = envOutput[3].trim();
-				}
-				if (!process.env['GOMODCACHE'] && envOutput[4] && envOutput[4].trim()) {
-					process.env['GOMODCACHE'] = envOutput[4].trim();
+				for (const envName in envOutput) {
+					if (!process.env[envName] && envOutput[envName] && envOutput[envName].trim()) {
+						process.env[envName] = envOutput[envName].trim();
+					}
 				}
 
 				// cgo, gopls, and other underlying tools will inherit the environment and attempt


### PR DESCRIPTION
If GOFLAGS environment variable contains "-json", the command will output json format and this causes line-by-line parsing of command execution results to fail. For example, result processing of `go env` or `go list` calls made by this extension in various places may fail. Remove "-json" or "--json=*" flags.

And when running `go env` in updateGoVarsFromConfig in src/goInstallTools.ts, utilize "-json" flag to simplify the result processing.