### PR TITLE
debugAdapter: fix missing file bug for remote debugging

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1133,7 +1133,7 @@ export class GoDebugSession extends LoggingDebugSession {
 	protected inferLocalPathFromRemotePath(remotePath: string): string | undefined {
 		// Don't try to infer a path for a file that does not exist
 		if (remotePath === '') {
-			return remotePath
+			return remotePath;
 		}
 
 		if (this.remoteToLocalPathMapping.has(remotePath)) {

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -1131,6 +1131,11 @@ export class GoDebugSession extends LoggingDebugSession {
 	 * Cache the result in remoteToLocalPathMapping.
 	 */
 	protected inferLocalPathFromRemotePath(remotePath: string): string | undefined {
+		// Don't try to infer a path for a file that does not exist
+		if (remotePath === '') {
+			return remotePath
+		}
+
 		if (this.remoteToLocalPathMapping.has(remotePath)) {
 			return this.remoteToLocalPathMapping.get(remotePath);
 		}


### PR DESCRIPTION
Check if the path is non-empty in `inferRemotePathFromLocalPath`
Fixes golang/vscode-go#1447