### PR TITLE
Support check.v1 Test Suites

### DIFF
--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -180,7 +180,7 @@ async function debugTestAtCursor(
 	testFunctions: vscode.DocumentSymbol[],
 	goConfig: vscode.WorkspaceConfiguration
 ) {
-	const args = getTestFunctionDebugArgs(editor.document, testFunctionName, testFunctions);
+	const args = await getTestFunctionDebugArgs(editor.document, testFunctionName, testFunctions);
 	const tags = getTestTags(goConfig);
 	const buildFlags = tags ? ['-tags', tags] : [];
 	const flagsFromConfig = getTestFlags(goConfig);

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -41,8 +41,8 @@ const testFuncRegex = /^Test\P{Ll}.*|^Example\P{Ll}.*/u;
 const testMethodRegex = /^\(([^)]+)\)\.(Test\P{Ll}.*)$/u;
 const benchmarkRegex = /^Benchmark\P{Ll}.*/u;
 
-const checkPkg = '"gopkg.in/check.v1"'
-const testifyPkg = '"github.com/stretchr/testify/suite"'
+const checkPkg = '"gopkg.in/check.v1"';
+const testifyPkg = '"github.com/stretchr/testify/suite"';
 
 /**
  * Input to goTest.
@@ -148,17 +148,15 @@ export async function getTestFunctions(
 	}
 	const children = symbol.children;
 
-    // include test functions and methods from 3rd party testing packages
-    let containsExternalPackages = false;
-    const allExternalPackages = [checkPkg, testifyPkg];
-    allExternalPackages.forEach((pkg) => {
-        const ext = children.some(
-            (sym) => sym.kind === vscode.SymbolKind.Namespace && sym.name === pkg
-        );
-        if (ext) {
-            containsExternalPackages = ext;
-        }
-    });
+	// include test functions and methods from 3rd party testing packages
+	let containsExternalPackages = false;
+	const allExternalPackages = [checkPkg, testifyPkg];
+	allExternalPackages.forEach((pkg) => {
+		const ext = children.some((sym) => sym.kind === vscode.SymbolKind.Namespace && sym.name === pkg);
+		if (ext) {
+			containsExternalPackages = ext;
+		}
+	});
 	return children.filter(
 		(sym) =>
 			sym.kind === vscode.SymbolKind.Function &&
@@ -196,9 +194,9 @@ export function getTestFunctionDebugArgs(
 	}
 	const instanceMethod = extractInstanceTestName(testFunctionName);
 	if (instanceMethod) {
-        if (containsThirdPartyTestPackages(document, null, [checkPkg])) {
-		    return ['-check.f', `^${instanceMethod}$`];
-        }
+		if (containsThirdPartyTestPackages(document, null, [checkPkg])) {
+			return ['-check.f', `^${instanceMethod}$`];
+		}
 
 		const testFns = findAllTestSuiteRuns(document, testFunctions);
 		const testSuiteRuns = ['-test.run', `^${testFns.map((t) => t.name).join('|')}$`];
@@ -583,15 +581,15 @@ function targetArgs(testconfig: TestConfig): Array<string> {
 		if (testconfig.isBenchmark) {
 			params = ['-bench', util.format('^(%s)$', testconfig.functions.join('|'))];
 		} else {
-            const editor = vscode.window.activeTextEditor;
-            if (!editor) {
-                vscode.window.showInformationMessage('No editor is active.');
-                return;
-            }
-            if (!editor.document.fileName.endsWith('_test.go')) {
-                vscode.window.showInformationMessage('No tests found. Current file is not a test file.');
-                return;
-            }
+			const editor = vscode.window.activeTextEditor;
+			if (!editor) {
+				vscode.window.showInformationMessage('No editor is active.');
+				return;
+			}
+			if (!editor.document.fileName.endsWith('_test.go')) {
+				vscode.window.showInformationMessage('No tests found. Current file is not a test file.');
+				return;
+			}
 
 			let testFunctions = testconfig.functions;
 			let testMethods = testFunctions.filter((fn) => testMethodRegex.test(fn));
@@ -603,7 +601,7 @@ function targetArgs(testconfig: TestConfig): Array<string> {
 
 			// we might skip the '-run' param when running only external test package methods, which will
 			// result in running all the test methods, but in the case of testify, one of them should call
-            // testify's `suite.Run(...)`, which will cause the correct thing to happen
+			// testify's `suite.Run(...)`, which will cause the correct thing to happen
 			if (testFunctions.length > 0) {
 				if (testFunctions.length === 1) {
 					params = params.concat(['-run', util.format('^%s$', testFunctions[0])]);
@@ -612,11 +610,11 @@ function targetArgs(testconfig: TestConfig): Array<string> {
 				}
 			}
 			if (testMethods.length > 0) {
-                if (containsThirdPartyTestPackages(editor.document, null, [checkPkg])) {
-                    params = params.concat(['-check.f', util.format('^(%s)$', testMethods.join('|'))]);
-                } else if (containsThirdPartyTestPackages(editor.document, null, [testifyPkg])) {
-                    params = params.concat(['-testify.m', util.format('^(%s)$', testMethods.join('|'))]);
-                }
+				if (containsThirdPartyTestPackages(editor.document, null, [checkPkg])) {
+					params = params.concat(['-check.f', util.format('^(%s)$', testMethods.join('|'))]);
+				} else if (containsThirdPartyTestPackages(editor.document, null, [testifyPkg])) {
+					params = params.concat(['-testify.m', util.format('^(%s)$', testMethods.join('|'))]);
+				}
 			}
 		}
 		return params;
@@ -635,15 +633,23 @@ function removeRunFlag(flags: string[]): void {
 	}
 }
 
-export async function containsThirdPartyTestPackages(doc: vscode.TextDocument, token: vscode.CancellationToken, pkgs: string[]): Promise<boolean> {
-    const documentSymbolProvider = new GoDocumentSymbolProvider(true);
-    const allPackages = await documentSymbolProvider
-        .provideDocumentSymbols(doc, token)
-        .then(symbols => symbols[0].children)
-        .then(symbols => {
-            return symbols.filter(sym => sym.kind === vscode.SymbolKind.Namespace && pkgs.some((pkg) => {
-                sym.name === pkg;
-            }));
-        });
-    return allPackages.length > 0;
+export async function containsThirdPartyTestPackages(
+	doc: vscode.TextDocument,
+	token: vscode.CancellationToken,
+	pkgs: string[]
+): Promise<boolean> {
+	const documentSymbolProvider = new GoDocumentSymbolProvider(true);
+	const allPackages = await documentSymbolProvider
+		.provideDocumentSymbols(doc, token)
+		.then((symbols) => symbols[0].children)
+		.then((symbols) => {
+			return symbols.filter(
+				(sym) =>
+					sym.kind === vscode.SymbolKind.Namespace &&
+					pkgs.some((pkg) => {
+						sym.name === pkg;
+					})
+			);
+		});
+	return allPackages.length > 0;
 }

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -41,6 +41,9 @@ const testFuncRegex = /^Test\P{Ll}.*|^Example\P{Ll}.*/u;
 const testMethodRegex = /^\(([^)]+)\)\.(Test\P{Ll}.*)$/u;
 const benchmarkRegex = /^Benchmark\P{Ll}.*/u;
 
+const checkPkg = '"gopkg.in/check.v1"'
+const testifyPkg = '"github.com/stretchr/testify/suite"'
+
 /**
  * Input to goTest.
  */
@@ -144,13 +147,22 @@ export async function getTestFunctions(
 		return;
 	}
 	const children = symbol.children;
-	const testify = children.some(
-		(sym) => sym.kind === vscode.SymbolKind.Namespace && sym.name === '"github.com/stretchr/testify/suite"'
-	);
+
+    // include test functions and methods from 3rd party testing packages
+    let containsExternalPackages = false;
+    const allExternalPackages = [checkPkg, testifyPkg];
+    allExternalPackages.forEach((pkg) => {
+        const ext = children.some(
+            (sym) => sym.kind === vscode.SymbolKind.Namespace && sym.name === pkg
+        );
+        if (ext) {
+            containsExternalPackages = ext;
+        }
+    });
 	return children.filter(
 		(sym) =>
 			sym.kind === vscode.SymbolKind.Function &&
-			(testFuncRegex.test(sym.name) || (testify && testMethodRegex.test(sym.name)))
+			(testFuncRegex.test(sym.name) || (containsExternalPackages && testMethodRegex.test(sym.name)))
 	);
 }
 
@@ -184,9 +196,12 @@ export function getTestFunctionDebugArgs(
 	}
 	const instanceMethod = extractInstanceTestName(testFunctionName);
 	if (instanceMethod) {
+        if (containsThirdPartyTestPackages(document, null, [checkPkg])) {
+		    return ['-check.f', `^${instanceMethod}$`];
+        }
+
 		const testFns = findAllTestSuiteRuns(document, testFunctions);
 		const testSuiteRuns = ['-test.run', `^${testFns.map((t) => t.name).join('|')}$`];
-		const testSuiteTests = ['-testify.m', `^${instanceMethod}$`];
 		return [...testSuiteRuns, ...testSuiteTests];
 	} else {
 		return ['-test.run', `^${testFunctionName}$`];
@@ -568,17 +583,27 @@ function targetArgs(testconfig: TestConfig): Array<string> {
 		if (testconfig.isBenchmark) {
 			params = ['-bench', util.format('^(%s)$', testconfig.functions.join('|'))];
 		} else {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) {
+                vscode.window.showInformationMessage('No editor is active.');
+                return;
+            }
+            if (!editor.document.fileName.endsWith('_test.go')) {
+                vscode.window.showInformationMessage('No tests found. Current file is not a test file.');
+                return;
+            }
+
 			let testFunctions = testconfig.functions;
-			let testifyMethods = testFunctions.filter((fn) => testMethodRegex.test(fn));
-			if (testifyMethods.length > 0) {
-				// filter out testify methods
+			let testMethods = testFunctions.filter((fn) => testMethodRegex.test(fn));
+			if (testMethods.length > 0) {
+				// filter out methods
 				testFunctions = testFunctions.filter((fn) => !testMethodRegex.test(fn));
-				testifyMethods = testifyMethods.map(extractInstanceTestName);
+				testMethods = testMethods.map(extractInstanceTestName);
 			}
 
-			// we might skip the '-run' param when running only testify methods, which will result
-			// in running all the test methods, but one of them should call testify's `suite.Run(...)`
-			// which will result in the correct thing to happen
+			// we might skip the '-run' param when running only external test package methods, which will
+			// result in running all the test methods, but in the case of testify, one of them should call
+            // testify's `suite.Run(...)`, which will cause the correct thing to happen
 			if (testFunctions.length > 0) {
 				if (testFunctions.length === 1) {
 					params = params.concat(['-run', util.format('^%s$', testFunctions[0])]);
@@ -586,8 +611,12 @@ function targetArgs(testconfig: TestConfig): Array<string> {
 					params = params.concat(['-run', util.format('^(%s)$', testFunctions.join('|'))]);
 				}
 			}
-			if (testifyMethods.length > 0) {
-				params = params.concat(['-testify.m', util.format('^(%s)$', testifyMethods.join('|'))]);
+			if (testMethods.length > 0) {
+                if (containsThirdPartyTestPackages(editor.document, null, [checkPkg])) {
+                    params = params.concat(['-check.f', util.format('^(%s)$', testMethods.join('|'))]);
+                } else if (containsThirdPartyTestPackages(editor.document, null, [testifyPkg])) {
+                    params = params.concat(['-testify.m', util.format('^(%s)$', testMethods.join('|'))]);
+                }
 			}
 		}
 		return params;
@@ -604,4 +633,17 @@ function removeRunFlag(flags: string[]): void {
 	if (index !== -1) {
 		flags.splice(index, 2);
 	}
+}
+
+export async function containsThirdPartyTestPackages(doc: vscode.TextDocument, token: vscode.CancellationToken, pkgs: string[]): Promise<boolean> {
+    const documentSymbolProvider = new GoDocumentSymbolProvider(true);
+    const allPackages = await documentSymbolProvider
+        .provideDocumentSymbols(doc, token)
+        .then(symbols => symbols[0].children)
+        .then(symbols => {
+            return symbols.filter(sym => sym.kind === vscode.SymbolKind.Namespace && pkgs.some((pkg) => {
+                sym.name === pkg;
+            }));
+        });
+    return allPackages.length > 0;
 }

--- a/test/integration/test.test.ts
+++ b/test/integration/test.test.ts
@@ -17,14 +17,14 @@ import sinon = require('sinon');
 import vscode = require('vscode');
 
 suite('Test Go Test Args', () => {
-	function runTest(param: {
+	async function runTest(param: {
 		expectedArgs: string;
 		expectedOutArgs: string;
 		flags?: string[];
 		functions?: string[];
 		isBenchmark?: boolean;
 	}) {
-		const { args, outArgs } = computeTestCommand(
+		const { args, outArgs } = await computeTestCommand(
 			{
 				dir: '',
 				goConfig: getGoConfig(),
@@ -40,57 +40,57 @@ suite('Test Go Test Args', () => {
 		assert.strictEqual(outArgs.join(' '), param.expectedOutArgs, 'displayed command');
 	}
 
-	test('default config', () => {
-		runTest({
+	test('default config', async () => {
+		await runTest({
 			expectedArgs: 'test -timeout 30s ./...',
 			expectedOutArgs: 'test -timeout 30s ./...'
 		});
 	});
-	test('user flag [-v] enables -json flag', () => {
-		runTest({
+	test('user flag [-v] enables -json flag', async () => {
+		await runTest({
 			expectedArgs: 'test -timeout 30s -json ./... -v',
 			expectedOutArgs: 'test -timeout 30s ./... -v',
 			flags: ['-v']
 		});
 	});
-	test('user flag [-json -v] prevents -json flag addition', () => {
-		runTest({
+	test('user flag [-json -v] prevents -json flag addition', async () => {
+		await runTest({
 			expectedArgs: 'test -timeout 30s ./... -json -v',
 			expectedOutArgs: 'test -timeout 30s ./... -json -v',
 			flags: ['-json', '-v']
 		});
 	});
-	test('user flag [-args] does not crash', () => {
-		runTest({
+	test('user flag [-args] does not crash', async () => {
+		await runTest({
 			expectedArgs: 'test -timeout 30s ./... -args',
 			expectedOutArgs: 'test -timeout 30s ./... -args',
 			flags: ['-args']
 		});
 	});
-	test('user flag [-args -v] does not enable -json flag', () => {
-		runTest({
+	test('user flag [-args -v] does not enable -json flag', async () => {
+		await runTest({
 			expectedArgs: 'test -timeout 30s ./... -args -v',
 			expectedOutArgs: 'test -timeout 30s ./... -args -v',
 			flags: ['-args', '-v']
 		});
 	});
-	test('specifying functions adds -run flags', () => {
-		runTest({
+	test('specifying functions adds -run flags', async () => {
+		await runTest({
 			expectedArgs: 'test -timeout 30s -run ^(TestA|TestB)$ ./...',
 			expectedOutArgs: 'test -timeout 30s -run ^(TestA|TestB)$ ./...',
 			functions: ['TestA', 'TestB']
 		});
 	});
-	test('functions & benchmark adds -bench flags and skips timeout', () => {
-		runTest({
+	test('functions & benchmark adds -bench flags and skips timeout', async () => {
+		await runTest({
 			expectedArgs: 'test -benchmem -run=^$ -bench ^(TestA|TestB)$ ./...',
 			expectedOutArgs: 'test -benchmem -run=^$ -bench ^(TestA|TestB)$ ./...',
 			functions: ['TestA', 'TestB'],
 			isBenchmark: true
 		});
 	});
-	test('user -run flag is ignored when functions are provided', () => {
-		runTest({
+	test('user -run flag is ignored when functions are provided', async () => {
+		await runTest({
 			expectedArgs: 'test -timeout 30s -run ^(TestA|TestB)$ ./...',
 			expectedOutArgs: 'test -timeout 30s -run ^(TestA|TestB)$ ./...',
 			functions: ['TestA', 'TestB'],


### PR DESCRIPTION
Fixes https://github.com/golang/vscode-go/issues/111

This PR roughly follows the code snippet outlined here: https://github.com/microsoft/vscode-go/issues/1921#issuecomment-514892108 to ensure that codelens is available for not just stretchr/testify, but also gopkg.in/check.v1.

The associated issue (https://github.com/golang/vscode-go/issues/111) and linked issues discuss support for other testing suites as well (https://github.com/golang/vscode-go/issues/228), however I did not add them as I am not familiar with them.

Taking that in to consideration, I'd love comments on:

- Is this a reasonable approach in general? It does change a few functions to by async, but the logical flow remains the same as all callers simply await as well.
- Should we spend the time to integrate a more flexible system for adding/updating testing packages? That would probably be outside the scope of this PR, but if that approach is preferred, that's pretty reasonable.

Also, this is my first contribution, and I believe I've followed the contributing guide, but please let me know if there is anything I can do to make this smoother! Thanks!