### PR TITLE
src/goTest: Add command Test Function At Cursor or Test Previous

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -35,6 +35,10 @@ List all the Go tools being used by this extension along with their locations.
 
 Runs a unit test at the cursor.
 
+### `Go: Test Function At Cursor or Test Previous`
+
+Runs a unit test at the cursor if one is found, otherwise re-runs the last executed test.
+
 ### `Go: Subtest At Cursor`
 
 Runs a sub test at the cursor.

--- a/package.json
+++ b/package.json
@@ -202,6 +202,11 @@
         "description": "Runs a unit test at the cursor."
       },
       {
+        "command": "go.test.cursorOrPrevious",
+        "title": "Go: Test Function At Cursor or Test Previous",
+        "description": "Runs a unit test at the cursor if one is found, otherwise re-runs the last executed test."
+      },
+      {
         "command": "go.subtest.cursor",
         "title": "Go: Subtest At Cursor",
         "description": "Runs a sub test at the cursor."

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -64,6 +64,7 @@ import {
 	debugPrevious,
 	subTestAtCursor,
 	testAtCursor,
+	testAtCursorOrPrevious,
 	testCurrentFile,
 	testCurrentPackage,
 	testPrevious,
@@ -313,6 +314,13 @@ If you would like additional configuration for diagnostics from gopls, please se
 		vscode.commands.registerCommand('go.test.cursor', (args) => {
 			const goConfig = getGoConfig();
 			testAtCursor(goConfig, 'test', args);
+		})
+	);
+
+	ctx.subscriptions.push(
+		vscode.commands.registerCommand('go.test.cursorOrPrevious', (args) => {
+			const goConfig = getGoConfig();
+			testAtCursorOrPrevious(goConfig, 'test', args);
 		})
 	);
 


### PR DESCRIPTION
This runs `Test Function At Cursor` if a unit test is found at the
cursor, otherwise it turns `Test Previous`.

Fixes golang/vscode-go#1508

