### PR TITLE
src/goFormat.ts: pass filename to custom formatters

### DIFF
--- a/src/goFormat.ts
+++ b/src/goFormat.ts
@@ -48,6 +48,10 @@ export class GoDocumentFormattingEditProvider implements vscode.DocumentFormatti
 			formatFlags.push('-style=indent=' + options.tabSize);
 		}
 
+		if (usingCustomFormatTool(goConfig)) {
+			formatFlags.push(filename)
+		}
+
 		return this.runFormatter(formatTool, formatFlags, document, token).then(
 			(edits) => edits,
 			(err) => {


### PR DESCRIPTION
Fixes #1603 