### PR TITLE
.github/workflows: add go1.17 rc1 in the long tests

### DIFF
--- a/.github/workflows/test-long-all.yml
+++ b/.github/workflows/test-long-all.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         version: ['stable', 'insiders']
-        go: ['1.15', '1.16']
+        go: ['1.15', '1.16', '1.17.0-rc1']
 
     steps:
       - name: Clone repository

--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest] # TODO: reenable macos-latest
         version: ['stable']
-        go: ['1.15', '1.16']
+        go: ['1.15', '1.16', '1.17.0-rc1']
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
Once it becomes stable, we plan to expand the nightly, and smoke tests to include go1.17rc1.