### PR TITLE
src/goMain: export a small API

### DIFF
--- a/src/export.d.ts
+++ b/src/export.d.ts
@@ -1,0 +1,19 @@
+import { Uri } from 'vscode';
+export { ToolAtVersion } from './goTools';
+
+export interface CommandInvocation {
+	binPath: string;
+	args?: string[];
+	env?: Object;
+	cwd?: string;
+}
+
+export interface ExtensionAPI {
+	settings: {
+		/**
+		 * Returns the execution command corresponding to the specified resource, taking into account
+		 * any workspace-specific settings for the workspace to which this resource belongs.
+		 */
+		getExecutionCommand(toolName: string, resource?: Uri): CommandInvocation | undefined;
+	};
+}

--- a/src/export.d.ts
+++ b/src/export.d.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------
+ * Copyright 2021 The Go Authors. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------*/
+
 import { Uri } from 'vscode';
 export { ToolAtVersion } from './goTools';
 

--- a/src/extensionAPI.ts
+++ b/src/extensionAPI.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------
+ * Copyright 2021 The Go Authors. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------*/
+
 import { Uri } from 'vscode';
 import { CommandInvocation, ExtensionAPI } from './export';
 import { getBinPathWithExplanation } from './util';

--- a/src/extensionAPI.ts
+++ b/src/extensionAPI.ts
@@ -1,0 +1,14 @@
+import { Uri } from 'vscode';
+import { CommandInvocation, ExtensionAPI } from './export';
+import { getBinPathWithExplanation } from './util';
+
+const api: ExtensionAPI = {
+	settings: {
+		getExecutionCommand(toolName: string, resource?: Uri): CommandInvocation | undefined {
+			const { binPath } = getBinPathWithExplanation(toolName, true, resource);
+			return { binPath };
+		}
+	}
+};
+
+export default api;

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -112,6 +112,8 @@ import semver = require('semver');
 import vscode = require('vscode');
 import { getFormatTool } from './goFormat';
 import { resetSurveyConfig, showSurveyConfig, timeMinute } from './goSurvey';
+import { ExtensionAPI } from './export';
+import extensionAPI from './extensionAPI';
 
 export let buildDiagnosticCollection: vscode.DiagnosticCollection;
 export let lintDiagnosticCollection: vscode.DiagnosticCollection;
@@ -124,7 +126,7 @@ export let restartLanguageServer = () => {
 	return;
 };
 
-export async function activate(ctx: vscode.ExtensionContext) {
+export async function activate(ctx: vscode.ExtensionContext): Promise<ExtensionAPI> {
 	if (process.env['VSCODE_GO_IN_TEST'] === '1') {
 		// Make sure this does not run when running in test.
 		return;
@@ -705,6 +707,8 @@ If you would like additional configuration for diagnostics from gopls, please se
 	vscode.languages.setLanguageConfiguration(GO_MODE.language, {
 		wordPattern: /(-?\d*\.\d\w*)|([^`~!@#%^&*()\-=+[{\]}\\|;:'",.<>/?\s]+)/g
 	});
+
+	return extensionAPI;
 }
 
 function showGoWelcomePage(ctx: vscode.ExtensionContext) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -518,8 +518,12 @@ export function getBinPath(tool: string, useCache = true): string {
 
 // getBinPathWithExplanation returns the path to the tool, and the explanation on why
 // the path was chosen. See getBinPathWithPreferredGopathGorootWithExplanation for details.
-export function getBinPathWithExplanation(tool: string, useCache = true): { binPath: string; why?: string } {
-	const cfg = getGoConfig();
+export function getBinPathWithExplanation(
+	tool: string,
+	useCache = true,
+	uri?: vscode.Uri
+): { binPath: string; why?: string } {
+	const cfg = getGoConfig(uri);
 	const alternateTools: { [key: string]: string } = cfg.get('alternateTools');
 	const alternateToolPath: string = alternateTools[tool];
 


### PR DESCRIPTION
Exports a function for use by other extensions. When I'm creating a
Go-related VSCode extension, being able to reuse this extension's
configuration and certain helper functions would be very useful.
Additionally, users expect Go-related extensions to respect `go.*`
configuration options, and have reported issues when they don't. This
change exports `getBinPath`. With this function, Go-related
extensions don't have to reinvent the wheel when it comes to
installing and configuring Go tools.

Updates golang/vscode-go#233