### PR TITLE
src/goInstallTools.ts: correct spacing in error message on Go not found

### DIFF
--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -365,6 +365,7 @@ Run "go get -v ${getImportPath(tool, goVersion)}" to install.`;
 		msg = `The ["${tool.name}"](https://github.com/golang/vscode-go/blob/master/docs/dlv-dap.md) command is not available.
 Please select "Install", or follow the installation instructions [here](https://github.com/golang/vscode-go/blob/master/docs/dlv-dap.md#updating-dlv-dap).`;
 	}
+
 	const selected = await vscode.window.showErrorMessage(msg, ...installOptions);
 	switch (selected) {
 		case 'Install':
@@ -591,9 +592,10 @@ let suggestedDownloadGo = false;
 
 async function suggestDownloadGo() {
 	const msg =
-		`Failed to find the "go" binary in either GOROOT(${getCurrentGoRoot()}) or PATH(${envPath}).` +
+		`Failed to find the "go" binary in either GOROOT(${getCurrentGoRoot()}) or PATH(${envPath}). ` +
 		'Check PATH, or Install Go and reload the window. ' +
 		"If PATH isn't what you expected, see https://github.com/golang/vscode-go/issues/971";
+
 	if (suggestedDownloadGo) {
 		vscode.window.showErrorMessage(msg);
 		return;
@@ -617,7 +619,9 @@ export async function latestToolVersion(tool: Tool, includePrerelease?: boolean)
 	const goCmd = getBinPath('go');
 	const tmpDir = await tmpDirForToolInstallation();
 	const execFile = util.promisify(cp.execFile);
+
 	let ret: semver.SemVer | null = null;
+
 	try {
 		const env = toolInstallationEnvironment();
 		env['GO111MODULE'] = 'on';
@@ -690,10 +694,12 @@ export async function shouldUpdateTool(tool: Tool, toolPath: string): Promise<bo
 	if (checkForUpdates === 'off') {
 		return false;
 	}
+
 	const { moduleVersion } = await inspectGoToolVersion(toolPath);
 	if (!moduleVersion) {
 		return false; // failed to inspect the tool version.
 	}
+
 	const localVersion = semver.parse(moduleVersion, { includePrerelease: true });
 	if (!localVersion) {
 		// local version can't be determined. e.g. (devel)


### PR DESCRIPTION
- Add space to fix bad message. ").Check PATH" to "). Check PATH".
- Add empty lines to break up dense code (a lot of lines without spaces) into logical groups.