### PR TITLE
src/goImpl: allow `-` as an acceptable char for interface names (package/variable)

### DIFF
--- a/src/goImpl.ts
+++ b/src/goImpl.ts
@@ -15,7 +15,7 @@ import { getBinPath } from './util';
 import vscode = require('vscode');
 
 // Supports only passing interface, see TODO in implCursor to finish
-const inputRegex = /^(\w+\ \*?\w+\ )?([\w./]+)$/;
+const inputRegex = /^(\w+\ \*?\w+\ )?([\w\.\-\/]+)$/;
 
 export function implCursor() {
 	const editor = vscode.window.activeTextEditor;


### PR DESCRIPTION
Fixes golang/vscode-go#1670

