### PR TITLE
src/goDebugFactory: fix debugger launch on Windows

### DIFF
--- a/src/goDebugFactory.ts
+++ b/src/goDebugFactory.ts
@@ -439,7 +439,7 @@ function spawnDlvDapServerProcess(
 		p.stderr.on('data', (chunk) => {
 			logErr(chunk.toString());
 		});
-		p.stdio[3].on('data', (chunk) => {
+		p.stdio[3]?.on('data', (chunk) => {
 			const msg = chunk.toString();
 			if (!started && msg.startsWith('DAP server listening at:')) {
 				stopWaitingForServerToStart();
@@ -456,10 +456,11 @@ function spawnDlvDapServerProcess(
 				logConsole(msg);
 			}
 		});
-		p.stdio[3].on('close', () => {
+		p.stdio[3]?.on('close', () => {
 			// always false on windows.
 			logDestStream?.end();
 		});
+
 		p.on('close', (code, signal) => {
 			// TODO: should we watch 'exit' instead?
 


### PR DESCRIPTION
https://go-review.googlesource.com/c/vscode-go/+/342632 introduced
a bug. On windows, tests fail with

-> server: {"type":"request","seq":1,"command":"initialize","arguments":{"adapterID":"go","linesStartAt1":true,"columnsStartAt1":true,"pathFormat":"path"}}
<- server: {"seq":0,"type":"response","request_seq":1,"success":false,"command":"initialize","message":"Couldn't start dlv dap:\nTypeError: Cannot read property 'on' of undefined"}
<- server: {"seq":0,"type":"event","event":"output","body":{"category":"stdout","output":"DAP server listening at: 127.0.0.1:59678\n"}}
<- server: {"seq":0,"type":"event","event":"output","body":{"category":"stderr","output":"2021-08-27T22:34:12Z debug layer=dap DAP server pid = 3344\n"}}

rejected promise not handled within 1 second: Error: Couldn't start dlv dap:
TypeError: Cannot read property 'on' of undefined
stack trace: Error: Couldn't start dlv dap:
TypeError: Cannot read property 'on' of undefined
	at d:\a\vscode-go\vscode-go\node_modules\vscode-debugadapter-testsupport\lib\protocolClient.js:29:35
	at DebugClient.dispatch (d:\a\vscode-go\vscode-go\node_modules\vscode-debugadapter-testsupport\lib\protocolClient.js:91:17)
	at DebugClient.handleData (d:\a\vscode-go\vscode-go\node_modules\vscode-debugadapter-testsupport\lib\protocolClient.js:57:30)
	at Socket.<anonymous> (d:\a\vscode-go\vscode-go\node_modules\vscode-debugadapter-testsupport\lib\protocolClient.js:19:18)
	at Socket.emit (events.js:315:20)
	at addChunk (internal/streams/readable.js:309:12)
	at readableAddChunk (internal/streams/readable.js:284:9)
	at Socket.Readable.push (internal/streams/readable.js:223:10)
	at TCP.onStreamRead (internal/stream_base_commons.js:188:23)
