### PR TITLE
src/goTest: ensure that cursorOrPrevious always saves

### DIFF
--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -88,14 +88,20 @@ export function testAtCursor(goConfig: vscode.WorkspaceConfiguration, cmd: TestA
  * @param cmd Whether the command is test, benchmark, or debug.
  * @param args
  */
-export function testAtCursorOrPrevious(goConfig: vscode.WorkspaceConfiguration, cmd: TestAtCursorCmd, args: any) {
-	_testAtCursor(goConfig, cmd, args).catch((err) => {
+export async function testAtCursorOrPrevious(goConfig: vscode.WorkspaceConfiguration, cmd: TestAtCursorCmd, args: any) {
+	try {
+		await _testAtCursor(goConfig, cmd, args);
+	} catch (err) {
 		if (err instanceof NotFoundError) {
-			testPrevious();
+			const editor = vscode.window.activeTextEditor;
+			if (editor) {
+				await editor.document.save();
+			}
+			await testPrevious();
 		} else {
 			console.error(err);
 		}
-	});
+	}
 }
 
 /**


### PR DESCRIPTION
In the case of cursorOrPrevious command not finding a Go test under the 
cursor, it will call go.test.previous. However, cursorOrPrevious 
automatically saves when there was a test found, but previous does not. 
This can lead to the user being surprised as to why doesn't 
cursorOrPrevious always save.

Followup to https://github.com/golang/vscode-go/pull/1509
