### PR TITLE
debug: allow debugAdapter=dlv-dap with remote attach mode

### DIFF
--- a/test/integration/goDebugConfiguration.test.ts
+++ b/test/integration/goDebugConfiguration.test.ts
@@ -887,13 +887,13 @@ suite('Debug Configuration Default DebugAdapter', () => {
 			cwd: '/path'
 		};
 
-		const want = 'legacy'; // remote mode works only with legacy mode.
+		const want = 'legacy'; // Remote mode defaults to legacy mode.
 		debugConfigProvider.resolveDebugConfiguration(undefined, config);
 		const resolvedConfig = config as any;
 		assert.strictEqual(resolvedConfig['debugAdapter'], want);
 	});
 
-	test('debugAdapter=dlv-dap should be ignored for remote mode', () => {
+	test('debugAdapter=dlv-dap is allowed with remote mode', () => {
 		const config = {
 			name: 'Attach',
 			type: 'go',
@@ -904,7 +904,7 @@ suite('Debug Configuration Default DebugAdapter', () => {
 			cwd: '/path'
 		};
 
-		const want = 'legacy'; // remote mode works only with legacy mode.
+		const want = 'dlv-dap'; // If requested, dlv-dap is preserved.
 		debugConfigProvider.resolveDebugConfiguration(undefined, config);
 		const resolvedConfig = config as any;
 		assert.strictEqual(resolvedConfig['debugAdapter'], want);


### PR DESCRIPTION
If debug adapter is not specified, still default to `legacy` for remote attach in case users haven't updated their tools to newer version of dlv that supports this via DAP. We can flip the default in a couple of months. In the meantime, users will need to specify directly if they want to use `dlv-dap` adapter. There is no good way to detect the version of a running server, so we will always allow them to proceed, while providing a warning about the right version at session start-up and at shutdown via Go Debug output channel if we detect that the connection failed with no responses.

After this change, we will have the following behavior:
attach + remote + debugAdapter=   => legacy
attach + remote + debugAdapter=dlv-dap => dlv-dap + version warnings
attach + remote + debugAdapter=legacy => legacy

attach + !remote + debugAdapter=dlv-dap + port => warning to drop port if not using external server
launch + !remote + debugAdapter=dlv-dap + port => warning to drop port if not using external server
launch + remote  + debugAdapter=dlv-dap + port => error from dlv server

Updates golang/vscode-go#1861