### PR TITLE
stop debugger when delve remote connection ends

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -709,9 +709,9 @@ export class Delve {
 
 					conn.on('connect', () => resolve(conn))
 						.on('error', reject)
-						.on('end', () => {
-							logError('Socket connection was closed');
-							onClose?.(1);
+						.on('close', (hadError) => {
+							logError('Socket connection to remote was closed');
+							onClose?.(hadError ? 1 : 0);
 						});
 				}, 200);
 			}

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -456,7 +456,7 @@ export class Delve {
 				this.isRemoteDebugging = true;
 				this.goroot = await queryGOROOT(dlvCwd, process.env);
 				serverRunning = true; // assume server is running when in remote mode
-				connectClient(launchArgs.port, launchArgs.host);
+				connectClient(launchArgs.port, launchArgs.host, this.onclose);
 				return;
 			}
 			this.isRemoteDebugging = false;
@@ -701,18 +701,18 @@ export class Delve {
 				env
 			});
 
-			function connectClient(port: number, host: string) {
+			function connectClient(port: number, host: string, onClose?: Delve['onclose']) {
 				// Add a slight delay to avoid issues on Linux with
 				// Delve failing calls made shortly after connection.
 				setTimeout(() => {
-					const client = Client.$create(port, host);
-					client.connectSocket((err, conn) => {
-						if (err) {
-							return reject(err);
-						}
-						return resolve(conn);
-					});
-					client.on('error', reject);
+					const conn = Client.$create(port, host).connectSocket();
+
+					conn.on('connect', () => resolve(conn))
+						.on('error', reject)
+						.on('end', () => {
+							logError('Socket connection was closed');
+							onClose?.(1);
+						});
 				}, 200);
 			}
 
@@ -729,7 +729,7 @@ export class Delve {
 				}
 				if (!serverRunning) {
 					serverRunning = true;
-					connectClient(launchArgs.port, launchArgs.host);
+					connectClient(launchArgs.port, launchArgs.host, this.onclose);
 				}
 			});
 			this.debugProcess.on('close', (code) => {

--- a/typings/json-rpc2.d.ts
+++ b/typings/json-rpc2.d.ts
@@ -1,8 +1,9 @@
 declare module 'json-rpc2' {
 	export interface RPCConnection {
 		call<T>(command: string, args: any[], callback: (err: Error, result: T) => void): void;
-		on(event: 'connect' | 'end', cb: () => {}): this;
+		on(event: 'connect', cb: () => {}): this;
 		on(event: 'error', cb: (err: Error) => {}): this;
+		on(event: 'close', cb: (hadError: boolean) => {}): this;
 		on(event: string, cb: Function): this;
 	}
 

--- a/typings/json-rpc2.d.ts
+++ b/typings/json-rpc2.d.ts
@@ -1,11 +1,13 @@
-declare module "json-rpc2" {
+declare module 'json-rpc2' {
 	export interface RPCConnection {
-		call<T>(command: string, args: any[], callback: (err: Error, result:T) => void): void;
+		call<T>(command: string, args: any[], callback: (err: Error, result: T) => void): void;
+		on(event: 'connect' | 'end', cb: () => {}): this;
+		on(event: 'error', cb: (err: Error) => {}): this;
+		on(event: string, cb: Function): this;
 	}
-	
+
 	export class Client {
 		static $create(port: number, addr: string): Client;
-		connectSocket(callback: (err: Error, conn: RPCConnection) => void): void;
-		on(handler: 'error', callback: (err: Error) => void): void;
+		connectSocket(): RPCConnection;
 	}
 }


### PR DESCRIPTION
Fixes the debugger appearing to be connected
to the remote server even though the connection
was terminated.
