### PR TITLE
src/goDebugConfiguration: infer default mode property

### DIFF
--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -141,6 +141,15 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 			debugConfiguration['type'] = this.defaultDebugAdapterType;
 		}
 
+		if (!debugConfiguration['mode']) {
+			if (debugConfiguration.request === 'launch') {
+				// 'auto' will decide mode by checking file extensions later
+				debugConfiguration['mode'] = 'auto';
+			} else if (debugConfiguration.request === 'attach') {
+				debugConfiguration['mode'] = 'local';
+			}
+		}
+
 		debugConfiguration['packagePathToGoModPathMap'] = packagePathToGoModPathMap;
 
 		const goConfig = getGoConfig(folder && folder.uri);

--- a/test/integration/goDebugConfiguration.test.ts
+++ b/test/integration/goDebugConfiguration.test.ts
@@ -920,3 +920,45 @@ suite('Debug Configuration Default DebugAdapter', () => {
 		assert.strictEqual(resolvedConfig['debugAdapter'], want);
 	});
 });
+
+suite('Debug Configuration Infers Default Mode Property', () => {
+	const debugConfigProvider = new GoDebugConfigurationProvider();
+	test("default mode for launch requests and test Go programs should be 'test'", () => {
+		const config = {
+			name: 'Launch',
+			type: 'go',
+			request: 'launch',
+			program: '/path/to/main_test.go'
+		};
+
+		debugConfigProvider.resolveDebugConfiguration(undefined, config);
+		const resolvedConfig = config as any;
+		assert.strictEqual(resolvedConfig['mode'], 'test');
+	});
+
+	test("default mode for launch requests and non-test Go programs should be 'debug'", () => {
+		const config = {
+			name: 'Launch',
+			type: 'go',
+			request: 'launch',
+			program: '/path/to/main.go'
+		};
+
+		debugConfigProvider.resolveDebugConfiguration(undefined, config);
+		const resolvedConfig = config as any;
+		assert.strictEqual(resolvedConfig['mode'], 'debug');
+	});
+
+	test("default mode for attach requests should be 'local'", () => {
+		const config = {
+			name: 'Attach',
+			type: 'go',
+			request: 'attach',
+			program: '/path/to/main.go'
+		};
+
+		debugConfigProvider.resolveDebugConfiguration(undefined, config);
+		const resolvedConfig = config as any;
+		assert.strictEqual(resolvedConfig['mode'], 'local');
+	});
+});


### PR DESCRIPTION
The mode property in launch.json defaults to local for attach requests.
However, if mode property for attach requests is omitted, 
configs returned by resolveDebugConfiguration() have undefined mode.

This leads to cannot unmarshal string into processId to type int error
due to skipping parseInt in resolveDebugConfigurationWithSubstitutedVariables
hook when using command:pickGoProcess.

This change fixes the issue by setting the default value.

Fixes golang/vscode-go#1929
