### PR TITLE
src/goDebugFactory: improve start-up and session fail messages for remote dlv-dap

### DIFF
--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -175,7 +175,7 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 				// but we have no way of detectng that with an external server.
 				this.showWarning(
 					'ignoreDlvDAPInRemoteModeWarning',
-					"'remote' mode with 'dlv-dap' debugAdapter must connect to an external `dlv --headless` server @ v1.7.3 or later. Older versions will fail with \"error layer=rpc rpc:invalid character 'C' looking for beginning of value\" logged to the terminal.\n"
+					"Using new 'remote' mode with 'dlv-dap' to connect to an external `dlv --headless` server via DAP."
 				);
 			} else if (debugConfiguration['port']) {
 				this.showWarning(

--- a/src/goDebugFactory.ts
+++ b/src/goDebugFactory.ts
@@ -17,6 +17,7 @@ import { Logger, TimestampedLogger } from './goLogging';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { getWorkspaceFolderPath } from './util';
 import { toolExecutionEnvironment } from './goEnv';
+import { ShowMessageNotification } from 'vscode-languageserver-protocol';
 
 export class GoDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
 	constructor(private outputChannel?: vscode.OutputChannel) {}
@@ -80,9 +81,10 @@ export class GoDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerF
 					requestsSent > 0 &&
 					responsesReceived === 0 // happens when the rpc server doesn't understand DAP
 				) {
-					logger.warn(
-						"'remote' mode with 'dlv-dap' debugAdapter must connect to an external headless server started with dlv @ v1.7.3 or later.\n"
-					);
+					const err =
+						'Expected to connect to external `dlv --headless` server @ v1.7.3 or later via DAP. Older versions fail with "error layer=rpc rpc:invalid character \'C\' looking for beginning of value" logged to the terminal.\n';
+					logger.warn(err);
+					vscode.window.showErrorMessage(err);
 				}
 				logger.debug(`session ${session.id} will stop\n`);
 			},

--- a/src/goDebugFactory.ts
+++ b/src/goDebugFactory.ts
@@ -17,7 +17,6 @@ import { Logger, TimestampedLogger } from './goLogging';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { getWorkspaceFolderPath } from './util';
 import { toolExecutionEnvironment } from './goEnv';
-import { ShowMessageNotification } from 'vscode-languageserver-protocol';
 
 export class GoDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
 	constructor(private outputChannel?: vscode.OutputChannel) {}


### PR DESCRIPTION
Updates golang/vscode-go#1861
The informational message alerting the user that they are using new remote dlv-dap mode will always pop-up when remote attach session is started. The user has the option to disable it with "Do not show again". If connection/attach fail, an additional pop-up will occur to high-light that this is dlv-dap mode that requires newer versions of dlv.
