### PR TITLE
docs/debugging.md: fix typo in gcflags

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -87,7 +87,7 @@ You can choose "Start Debugging (F5)" and "Run Without Debugging (^F5)" a.k.a th
     *   `debug`: build and debug a main package
     *   `test`: build and debug a test
     *   `exec`: debug a precompiled binary
-        * The binary must be built with `go build -gcflags=all="-N -l"` to disable inlining and optimizations that can interfere with debugging.
+        * The binary must be built with `go build -gcflags="all=-N -l"` to disable inlining and optimizations that can interfere with debugging.
     *   `auto`: automatically choose between `debug` and `test` depending on the open file
 
 ⚠️ If a `port` attribute is added to any of the launch configurations, it will signal VS Code that instead of launching the debug server internally, it should connect to an external user-specified `dlv dap` server at `host:port` and launch the target there. See ["Remote Debugging"](#remote-debugging) for more details).


### PR DESCRIPTION
Fixed typo in definition of gcflags which without fix results in non-runnable command.