### PR TITLE
package.json: fix spelling for generateTestForPackage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1769,7 +1769,7 @@
             "generateTestForPackage": {
               "type": "boolean",
               "default": true,
-              "description": "If true, adds command to generate unit tests for currnt package to the editor context menu"
+              "description": "If true, adds command to generate unit tests for current package to the editor context menu"
             },
             "addImport": {
               "type": "boolean",


### PR DESCRIPTION
Minor spelling fix on the settings description for generateTestForPackage.
