### PR TITLE
src/goGenerateTests: fix method can not generate test in gopls document symbol

### DIFF
--- a/src/goGenerateTests.ts
+++ b/src/goGenerateTests.ts
@@ -227,5 +227,5 @@ function generateTests(conf: Config, goConfig: vscode.WorkspaceConfiguration): P
 async function getFunctions(doc: vscode.TextDocument): Promise<vscode.DocumentSymbol[]> {
 	const documentSymbolProvider = new GoDocumentSymbolProvider();
 	const symbols = await documentSymbolProvider.provideDocumentSymbols(doc, null);
-	return symbols[0].children.filter((sym) => sym.kind === vscode.SymbolKind.Function);
+	return symbols[0].children.filter((sym) => [vscode.SymbolKind.Function, vscode.SymbolKind.Method].includes(sym.kind));
 }


### PR DESCRIPTION
Gopls's document symbol provider classifies methods correctly, while `go-outline`-based document symbol provider marks them as "function". The difference caused regression after change for golang/vscode-go#1020.

Fixes golang/vscode-go#2091