### PR TITLE
src/goDebugConfiguration: remove remote attach info pop-up

### DIFF
--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -172,13 +172,10 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 		}
 		if (debugConfiguration['debugAdapter'] === 'dlv-dap') {
 			if (debugConfiguration['mode'] === 'remote') {
-				// This is only possible if a user explicitely requests this combination. Let them, with a warning.
+				// This is only possible if a user explicitely requests this combination. Let them.
 				// They need to use dlv at version 'v1.7.3-0.20211026171155-b48ceec161d5' or later,
-				// but we have no way of detectng that with an external server.
-				this.showWarning(
-					'ignoreDlvDAPInRemoteModeWarning',
-					"Using new 'remote' mode with 'dlv-dap' to connect to an external `dlv --headless` server via DAP."
-				);
+				// but we have no way of detectng that with an external server ahead of time.
+				// If an earlier version is used, the attach will fail and a warning will warn about it.
 			} else if (debugConfiguration['port']) {
 				this.showWarning(
 					'ignorePortUsedInDlvDapWarning',


### PR DESCRIPTION
This change removes an informational pop-up at the start of remote attach session that was meant to announce to users that their dlv-dap setting was no longer ignored in that mode. In the past we defaulted to legacy regarding of the debugAdapter setting. Now that the intro period is over and the users also find this "announcement" confusing because it looks like an error, it is time to remove it. The users will be notified later in the session if their dlv version is too old to support remote attach and connection fails.

Fixes golang/vscode-go#2018