### PR TITLE
Add Snippets for t.Error and t.Errorf

### DIFF
--- a/snippets/go.json
+++ b/snippets/go.json
@@ -150,6 +150,16 @@
 			"body": "t.Logf(\"${1:var}: %#+v\\\\n\", ${1:var})",
 			"description": "Snippet for t.Logf() with variable content"
 		},
+		"t.Error": {
+			"prefix": "ter",
+			"body": "t.Error(\"$1\")",
+			"description": "Snippet for t.Error()"
+		},
+		"t.Errorf": {
+			"prefix": "terf",
+			"body": "t.Errorf(\"$1\", ${2:var})",
+			"description": "Snippet for t.Errorf()"
+		},
 		"make(...)": {
 			"prefix": "make",
 			"body": "make(${1:type}, ${2:0})",


### PR DESCRIPTION
Added the prefix `ter` and `terf`. Chose to do it that way because if I used the conventional way (`te` and `tef`) we would have the snippet for `te` before the `testing` package. Adding a 'r' at the end reduce the conflict.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `frob the quux before blarfing`
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes golang/vscode-go#1234` or `Updates golang/vscode-go#1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo, you can use the `owner/repo#issue_number` syntax:
  `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
