### PR TITLE
src/goTest: Use more robust method to find module name in go.mod

### DIFF
--- a/src/goTest/resolve.ts
+++ b/src/goTest/resolve.ts
@@ -32,8 +32,6 @@ const testFuncRegex = /^(?<name>(?<kind>Test|Benchmark|Example|Fuzz)($|\P{Ll}.*)
 const testMethodRegex = /^\(\*(?<type>[^)]+)\)\.(?<name>(?<kind>Test)($|\P{Ll}.*))$/u;
 const runTestSuiteRegex = /^\s*suite\.Run\(\w+,\s*(?:&?(?<type1>\w+)\{\}|new\((?<type2>\w+)\))\)/mu;
 
-// Tne 'name' group captures the module name, and the unnamed group ignores a comment that follows the name.
-const moduleNameRegex = /^module.(?<name>.*?)(?:\s|\/\/|$)/mu;
 interface TestSuite {
 	func?: TestItem;
 	methods: Set<TestItem>;

--- a/src/goTest/utils.ts
+++ b/src/goTest/utils.ts
@@ -116,7 +116,7 @@ export function disposeIfEmpty(resolver: GoTestResolver, item: vscode.TestItem) 
 	disposeIfEmpty(resolver, item.parent);
 }
 
-// Tne 'name' group captures the module name, and the unnamed group ignores a comment that follows the name.
+// The 'name' group captures the module name, and the unnamed group ignores any comment that might follow the name.
 const moduleNameRegex = /^module.(?<name>.*?)(?:\s|\/\/|$)/mu;
 
 export function findModuleName(goModContent: string): string {

--- a/src/goTest/utils.ts
+++ b/src/goTest/utils.ts
@@ -115,3 +115,14 @@ export function disposeIfEmpty(resolver: GoTestResolver, item: vscode.TestItem) 
 	dispose(resolver, item);
 	disposeIfEmpty(resolver, item.parent);
 }
+
+// Tne 'name' group captures the module name, and the unnamed group ignores a comment that follows the name.
+const moduleNameRegex = /^module.(?<name>.*?)(?:\s|\/\/|$)/mu;
+
+export function findModuleName(goModContent: string): string {
+	const match = goModContent.toString().match(moduleNameRegex);
+	if (match === null) {
+		throw new Error('failed to find module name in go.mod');
+	}
+	return match.groups.name;
+}

--- a/test/integration/goTest.resolve.test.ts
+++ b/test/integration/goTest.resolve.test.ts
@@ -40,6 +40,14 @@ suite('Go Test Resolver', () => {
 				},
 				expect: ['file:///src/proj?module']
 			},
+			'Module with leading comments': {
+				workspace: ['/src/proj'],
+				files: {
+					'/src/proj/go.mod': '// Example comment\nmodule test',
+					'/src/proj/main.go': 'package main'
+				},
+				expect: ['file:///src/proj?module']
+			},
 			'Basic workspace': {
 				workspace: ['/src/proj'],
 				files: {


### PR DESCRIPTION
The previous method found the name only if it appeared on the first line. However, it is legal for comments to precede the line with the module name.

The first commit is a failing integration test, and the second commit is the fix.

Fixes golang/vscode-go#2171