### PR TITLE
src/goDebugConfiguration: default to dlv-dap for remote in preview mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ provides rich language support for the
 [Go programming language](https://golang.org/).
 
 📣
-[Remote attach debugging](docs/debugging.md#connecting-to-headless-delve-with-target-specified-at-server-start-up) is now available via Delve's native DAP implementation with Delve v1.7.3 or newer.
-We plan to enable this as the default in early 2022 to enhance remote debugging with the same
-[debugging features](docs/debugging.md) that are already in use for local debugging.
+[Remote attach debugging](docs/debugging.md#connecting-to-headless-delve-with-target-specified-at-server-start-up) is now available via Delve's native DAP implementation with Delve v1.7.3 or newer. It enchances remote debugging with the same
+[debugging features](docs/debugging.md) that are already in use for local debugging. It is now the default with the
+[Go Nightly](docs/nightly.md) build of the extension and will become the default for the stable releases in mid 2022.
 We recommend switching your remote attach configurations in `launch.json` to use
 `"debugAdapter":"dlv-dap"` now to verify that this works for you.
 Please [file a new issue](https://github.com/golang/vscode-go/issues/new/choose) if you encounter any problems.

--- a/build/all.bash
+++ b/build/all.bash
@@ -81,7 +81,8 @@ prepare_nightly() {
 .displayName="Go Nightly" |
 .publisher="golang" |
 .description="Rich Go language support for Visual Studio Code (Nightly)" |
-.contributes.configuration.properties."go.delveConfig".properties.hideSystemGoroutines.default=true
+.contributes.configuration.properties."go.delveConfig".properties.hideSystemGoroutines.default=true |
+.contributes.configuration.properties."go.delveConfig".properties.debugAdapter.default="dlv-dap"
 ') > /tmp/package.json && mv /tmp/package.json package.json
 
   # Replace CHANGELOG.md with CHANGELOG.md + Release commit info.

--- a/build/all.bash
+++ b/build/all.bash
@@ -81,8 +81,7 @@ prepare_nightly() {
 .displayName="Go Nightly" |
 .publisher="golang" |
 .description="Rich Go language support for Visual Studio Code (Nightly)" |
-.contributes.configuration.properties."go.delveConfig".properties.hideSystemGoroutines.default=true |
-.contributes.configuration.properties."go.delveConfig".properties.debugAdapter.default="dlv-dap"
+.contributes.configuration.properties."go.delveConfig".properties.hideSystemGoroutines.default=true
 ') > /tmp/package.json && mv /tmp/package.json package.json
 
   # Replace CHANGELOG.md with CHANGELOG.md + Release commit info.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -6,7 +6,8 @@ These debugging features are possible by using [Delve](https://github.com/go-del
 The Go extension has been communicating with Delve through a custom debug adapter program (`legacy` mode).
 As the new [`Delve`'s native debug adapter implementation](https://github.com/go-delve/delve/tree/master/service/dap) has become available (since Delve v1.6.1), the Go extension is transitioning to deprecate the legacy debug adapter in favor of direct communication with Delve via [DAP](https://microsoft.github.io/debug-adapter-protocol/overview).
 
- 📣 **We are happy to announce that now this new mode of Delve integration (_`dlv-dap`_ mode) is enabled for _local_ _debugging_ by default and is available for [_remote_ _debugging_](#remote-debugging) on demand!**
+ 📣 **We are happy to announce that the new _`dlv-dap`_ mode of Delve integration is enabled for _local_ _debugging_ by default. For [_remote_ _debugging_](#remote-debugging) it is the default in [Go Nightly](docs/nightly.md) and is
+ available with stable builds on demand with `"debugAdapter": "dlv-dap"` attribute in `launch.json` or `settings.json`!**
 
 Many features and settings described in this document may be available only with the new `dlv-dap` mode.
 For troubleshooting and configuring the legacy debug adapter, see [the legacy debug adapter documentation](https://github.com/golang/vscode-go/tree/master/docs/debugging-legacy.md).

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -20,6 +20,7 @@ import {
 	promptForUpdatingTool,
 	shouldUpdateTool
 } from './goInstallTools';
+import { extensionInfo } from './config';
 import { packagePathToGoModPathMap } from './goModules';
 import { getToolAtVersion } from './goTools';
 import { pickProcess, pickProcessByName } from './pickProcess';
@@ -159,6 +160,7 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 
 		// Figure out which debugAdapter is being used first, so we can use this to send warnings
 		// for properties that don't apply.
+		// If debugAdapter is not provided in launch.json, see if it's in settings.json.
 		if (!debugConfiguration.hasOwnProperty('debugAdapter') && dlvConfig.hasOwnProperty('debugAdapter')) {
 			const { globalValue, workspaceValue } = goConfig.inspect('delveConfig.debugAdapter');
 			// user configured the default debug adapter through settings.json.
@@ -166,16 +168,19 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 				debugConfiguration['debugAdapter'] = dlvConfig['debugAdapter'];
 			}
 		}
+		// If neither launch.json nor settings.json gave us the debugAdapter value, we go with the default
+		// from package.json (dlv-dap) unless this is remote attach with a stable release.
 		if (!debugConfiguration['debugAdapter']) {
-			// For local modes, default to dlv-dap. For remote - to legacy for now.
-			debugConfiguration['debugAdapter'] = debugConfiguration['mode'] !== 'remote' ? 'dlv-dap' : 'legacy';
+			debugConfiguration['debugAdapter'] = defaultConfig.debugAdapter.default;
+			if (debugConfiguration['mode'] !== 'remote' && !extensionInfo.isPreview) {
+				debugConfiguration['debugAdapter'] = 'legacy';
+			}
 		}
 		if (debugConfiguration['debugAdapter'] === 'dlv-dap') {
 			if (debugConfiguration['mode'] === 'remote') {
-				// This is only possible if a user explicitely requests this combination. Let them.
-				// They need to use dlv at version 'v1.7.3-0.20211026171155-b48ceec161d5' or later,
+				// This needs to use dlv at version 'v1.7.3-0.20211026171155-b48ceec161d5' or later,
 				// but we have no way of detectng that with an external server ahead of time.
-				// If an earlier version is used, the attach will fail and a warning will warn about it.
+				// If an earlier version is used, the attach will fail with  warning about versions.
 			} else if (debugConfiguration['port']) {
 				this.showWarning(
 					'ignorePortUsedInDlvDapWarning',

--- a/test/integration/goDebugConfiguration.test.ts
+++ b/test/integration/goDebugConfiguration.test.ts
@@ -7,7 +7,7 @@ import os = require('os');
 import path = require('path');
 import sinon = require('sinon');
 import vscode = require('vscode');
-import { getGoConfig } from '../../src/config';
+import { getGoConfig, extensionInfo } from '../../src/config';
 import { GoDebugConfigurationProvider } from '../../src/goDebugConfiguration';
 import { updateGoVarsFromConfig } from '../../src/goInstallTools';
 import { rmdirRecursive } from '../../src/util';
@@ -915,7 +915,7 @@ suite('Debug Configuration Default DebugAdapter', () => {
 		assert.strictEqual(resolvedConfig['debugAdapter'], 'dlv-dap');
 	});
 
-	test("default debugAdapter for remote mode should be always 'legacy'", async () => {
+	test("default debugAdapter for remote mode should be 'legacy' when not in Preview mode", async () => {
 		const config = {
 			name: 'Attach',
 			type: 'go',
@@ -925,7 +925,7 @@ suite('Debug Configuration Default DebugAdapter', () => {
 			cwd: '/path'
 		};
 
-		const want = 'legacy'; // Remote mode defaults to legacy mode.
+		const want = extensionInfo.isPreview ? 'dlv-dap' : 'legacy';
 		await debugConfigProvider.resolveDebugConfiguration(undefined, config);
 		const resolvedConfig = config as any;
 		assert.strictEqual(resolvedConfig['debugAdapter'], want);


### PR DESCRIPTION
Follows this example: https://golang.org/cl/325581.

Fixes https://github.com/golang/vscode-go/issues/2168