### PR TITLE
.github/workflows: add go1.19rc2 to long/smoke tests

### DIFF
--- a/.github/workflows/test-long-all.yml
+++ b/.github/workflows/test-long-all.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         version: ['stable', 'insiders']
-        go: ['1.16', '1.17', '1.18']
+        go: ['1.16', '1.17', '1.18', '1.19.0-rc.2']
 
     steps:
       - name: Clone repository

--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest] # TODO: reenable macos-latest
         version: ['stable']
-        go: ['1.16', '1.17', '1.18']
+        go: ['1.16', '1.17', '1.18', '1.19.0-rc.2']
 
     steps:
       - name: Clone repository

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-         go-version: '1.18'
+         go-version: '1.19.0-rc.2'
          check-latest: true
          cache: true
 

--- a/docs/debugging-legacy.md
+++ b/docs/debugging-legacy.md
@@ -143,7 +143,7 @@ in your launch configuration. This property supports multiple tags, which you ca
 
 ### Specifying other build flags
 
-The flags specified in `buildFlags` and `env.GOFLAGS` are passed to the Go compiler when building your program for debugging. Delve adds `-gcflags='all=-N -l'` to the list of build flags to disable optimizations. User specified buildFlags conflict with this setting, so the extension removes them ([Issue #117](https://github.com/golang/vscode-go/issues/117)). If you wish to debug a program using custom `-gcflags`, build the program using `go build` and launch using `exec` mode:
+The flags specified in `buildFlags` and `env.GOFLAGS` are passed to the Go compiler when building your program for debugging. Delve adds `-gcflags=all="-N -l"` to the list of build flags to disable optimizations. User specified buildFlags conflict with this setting, so the extension removes them ([Issue #117](https://github.com/golang/vscode-go/issues/117)). If you wish to debug a program using custom `-gcflags`, build the program using `go build` and launch using `exec` mode:
 
 ```json
 {

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -568,7 +568,7 @@ Start a `dlv dap` server ready to accept a client request to launch or attach to
 $ dlv dap --listen=:12345
 ```
 
-Use the following `launch` configuration to tell `dlv` to execute a binary precompiled with `go build -gcflags='all=-N -l'`:
+Use the following `launch` configuration to tell `dlv` to execute a binary precompiled with `go build -gcflags=all="-N -l"`:
 
 ```json5
 {
@@ -655,7 +655,7 @@ The "debug test" CodeLens and the [test UI](features.md#test-and-benchmark) do n
 
 ### Starting a debug session fails with `decoding dwarf section info at offset 0x0: too short` or `could not open debug info` error.
 
-These errors indicate that your binary was built with linker flags that stripped the symbol table (`-s`) or the DWARF debug information (`-w`), making debugging impossible. If the binary is built while launching the session, make sure your `launch.json` configuration does not contain `"buildFlags": "--ldflags '-s -w'"`. If you use `debug test` or Test Explorer, check `go.buildFlags` in `settings.json`. If the binary is built externally, check the command-line flags and do not use `go run`. Unlike `go build`, `go run` passes `-s -w` to the linker under the hood. If you try to attach to such a binary with a debugger, it will fail with one of the above errors (see Go Issue [24833](https://github.com/golang/go/issues/24833)). Instead let dlv build the binary for you or use `go build -gcflags='all=-N -l'`.
+These errors indicate that your binary was built with linker flags that stripped the symbol table (`-s`) or the DWARF debug information (`-w`), making debugging impossible. If the binary is built while launching the session, make sure your `launch.json` configuration does not contain `"buildFlags": "--ldflags '-s -w'"`. If you use `debug test` or Test Explorer, check `go.buildFlags` in `settings.json`. If the binary is built externally, check the command-line flags and do not use `go run`. Unlike `go build`, `go run` passes `-s -w` to the linker under the hood. If you try to attach to such a binary with a debugger, it will fail with one of the above errors (see Go Issue [24833](https://github.com/golang/go/issues/24833)). Instead let dlv build the binary for you or use `go build -gcflags=all="-N -l"`.
 
 ## Reporting Issues
 

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -152,7 +152,7 @@ const testAll = (isModuleMode: boolean) => {
 		const uri = vscode.Uri.file(path.join(fixturePath, 'gogetdocTestData', 'test.go'));
 		const textDocument = await vscode.workspace.openTextDocument(uri);
 
-		const promises = testCases.map(([position, expected, expectedDoc, expectedParams]) =>
+		const promises = testCases.map(([position, expected, expectedDocPrefix, expectedParams]) =>
 			provider.provideSignatureHelp(textDocument, position, dummyCancellationSource.token).then((sigHelp) => {
 				assert.ok(
 					sigHelp,
@@ -160,7 +160,10 @@ const testAll = (isModuleMode: boolean) => {
 				);
 				assert.equal(sigHelp.signatures.length, 1, 'unexpected number of overloads');
 				assert.equal(sigHelp.signatures[0].label, expected);
-				assert.equal(sigHelp.signatures[0].documentation, expectedDoc);
+				assert(
+					sigHelp.signatures[0].documentation?.toString().startsWith(expectedDocPrefix),
+					`expected doc starting with ${expectedDocPrefix}, got ${JSON.stringify(sigHelp.signatures[0])}`
+				);
 				assert.equal(sigHelp.signatures[0].parameters.length, expectedParams.length);
 				for (let i = 0; i < expectedParams.length; i++) {
 					assert.equal(sigHelp.signatures[0].parameters[i].label, expectedParams[i]);
@@ -190,7 +193,10 @@ const testAll = (isModuleMode: boolean) => {
 				}
 				assert(res);
 				assert.equal(res.contents.length, 1);
-				assert.equal((<vscode.MarkdownString>res.contents[0]).value, expectedHover);
+				assert(
+					(<vscode.MarkdownString>res.contents[0]).value.startsWith(expectedHover),
+					`expected hover starting with ${expectedHover}, got ${JSON.stringify(res.contents[0])}`
+				);
 			})
 		);
 		return Promise.all(promises);
@@ -227,11 +233,7 @@ const testAll = (isModuleMode: boolean) => {
 			this.skip();
 		} // not working in module mode
 
-		const printlnDoc = `Println formats using the default formats for its operands and writes to
-standard output. Spaces are always added between operands and a newline is
-appended. It returns the number of bytes written and any write error
-encountered.
-`;
+		const printlnDocPrefix = 'Println formats using the default formats for its operands and writes';
 		const printlnSig = goVersion.lt('1.18')
 			? 'Println(a ...interface{}) (n int, err error)'
 			: 'Println(a ...any) (n int, err error)';
@@ -240,7 +242,7 @@ encountered.
 			[
 				new vscode.Position(19, 13),
 				printlnSig,
-				printlnDoc,
+				printlnDocPrefix,
 				[goVersion.lt('1.18') ? 'a ...interface{}' : 'a ...any']
 			],
 			[
@@ -278,10 +280,7 @@ encountered.
 			return;
 		}
 
-		const printlnDoc = `Println formats using the default formats for its operands and writes to standard output.
-Spaces are always added between operands and a newline is appended.
-It returns the number of bytes written and any write error encountered.
-`;
+		const printlnDocPrefix = 'Println formats using the default formats for its operands and writes';
 		const printlnSig = goVersion.lt('1.18')
 			? 'Println(a ...interface{}) (n int, err error)'
 			: 'Println(a ...any) (n int, err error)';
@@ -290,7 +289,7 @@ It returns the number of bytes written and any write error encountered.
 			[
 				new vscode.Position(19, 13),
 				printlnSig,
-				printlnDoc,
+				printlnDocPrefix,
 				[goVersion.lt('1.18') ? 'a ...interface{}' : 'a ...any']
 			],
 			[
@@ -323,11 +322,7 @@ It returns the number of bytes written and any write error encountered.
 			this.skip();
 		} // not working in module mode
 
-		const printlnDoc = `Println formats using the default formats for its operands and writes to
-standard output. Spaces are always added between operands and a newline is
-appended. It returns the number of bytes written and any write error
-encountered.
-`;
+		const printlnDocPrefix = 'Println formats using the default formats for its operands and writes';
 		const printlnSig = goVersion.lt('1.18')
 			? 'Println func(a ...interface{}) (n int, err error)'
 			: 'Println func(a ...any) (n int, err error)';
@@ -340,7 +335,7 @@ encountered.
 			[new vscode.Position(28, 16), null, null], // inside a number
 			[new vscode.Position(22, 5), 'main func()', '\n'],
 			[new vscode.Position(40, 23), 'import (math "math")', null],
-			[new vscode.Position(19, 6), printlnSig, printlnDoc],
+			[new vscode.Position(19, 6), printlnSig, printlnDocPrefix],
 			[
 				new vscode.Position(23, 4),
 				'print func(txt string)',
@@ -364,10 +359,7 @@ encountered.
 			return;
 		}
 
-		const printlnDoc = `Println formats using the default formats for its operands and writes to standard output.
-Spaces are always added between operands and a newline is appended.
-It returns the number of bytes written and any write error encountered.
-`;
+		const printlnDocPrefix = 'Println formats using the default formats for its operands and writes';
 		const printlnSig = goVersion.lt('1.18')
 			? 'func Println(a ...interface{}) (n int, err error)'
 			: 'func Println(a ...any) (n int, err error)';
@@ -388,7 +380,7 @@ It returns the number of bytes written and any write error encountered.
 				'package math',
 				'Package math provides basic constants and mathematical functions.\n\nThis package does not guarantee bit-identical results across architectures.\n'
 			],
-			[new vscode.Position(19, 6), printlnSig, printlnDoc],
+			[new vscode.Position(19, 6), printlnSig, printlnDocPrefix],
 			[
 				new vscode.Position(27, 14),
 				'type ABC struct {\n    a int\n    b int\n    c int\n}',
@@ -878,11 +870,7 @@ It returns the number of bytes written and any write error encountered.
 			this.skip(); // timeout on windows
 		}
 
-		const printlnDoc = `Println formats using the default formats for its operands and writes to
-standard output. Spaces are always added between operands and a newline is
-appended. It returns the number of bytes written and any write error
-encountered.
-`;
+		const printlnDocPrefix = 'Println formats using the default formats for its operands';
 		const printlnSig = goVersion.lt('1.18')
 			? 'func(a ...interface{}) (n int, err error)'
 			: 'func(a ...any) (n int, err error)';
@@ -890,7 +878,7 @@ encountered.
 		const provider = new GoCompletionItemProvider();
 		const testCases: [vscode.Position, string, string | null, string | null][] = [
 			[new vscode.Position(7, 4), 'fmt', 'fmt', null],
-			[new vscode.Position(7, 6), 'Println', printlnSig, printlnDoc]
+			[new vscode.Position(7, 6), 'Println', printlnSig, printlnDocPrefix]
 		];
 		const uri = vscode.Uri.file(path.join(fixturePath, 'baseTest', 'test.go'));
 		const textDocument = await vscode.workspace.openTextDocument(uri);
@@ -912,15 +900,20 @@ encountered.
 					if (!resolvedItemResult) {
 						return;
 					}
-					if (resolvedItemResult instanceof vscode.CompletionItem) {
-						if (resolvedItemResult.documentation) {
-							assert.equal((<vscode.MarkdownString>resolvedItemResult.documentation).value, expectedDoc);
+					const resolvedItem =
+						resolvedItemResult instanceof vscode.CompletionItem
+							? resolvedItemResult
+							: await resolvedItemResult;
+					if (resolvedItem?.documentation) {
+						const got = (<vscode.MarkdownString>resolvedItem.documentation).value;
+						if (expectedDoc) {
+							assert(
+								got.startsWith(expectedDoc),
+								`expected doc starting with ${expectedDoc}, got ${got}`
+							);
+						} else {
+							assert.equal(got, expectedDoc);
 						}
-						return;
-					}
-					const resolvedItem = await resolvedItemResult;
-					if (resolvedItem) {
-						assert.equal((<vscode.MarkdownString>resolvedItem.documentation).value, expectedDoc);
 					}
 				})
 		);

--- a/test/integration/goDebug.test.ts
+++ b/test/integration/goDebug.test.ts
@@ -2091,7 +2091,7 @@ const testAll = (ctx: Mocha.Context, isDlvDap: boolean, withConsole?: string) =>
 		async function buildGoProgram(cwd: string, outputFile: string): Promise<string> {
 			const goRuntimePath = getBinPath('go');
 			const execFile = util.promisify(cp.execFile);
-			const child = await execFile(goRuntimePath, ['build', '-o', outputFile, "--gcflags='all=-N -l'", '.'], {
+			const child = await execFile(goRuntimePath, ['build', '-o', outputFile, '--gcflags=all=-N -l', '.'], {
 				cwd
 			});
 			if (child.stderr.length > 0) {


### PR DESCRIPTION
go1.19 release will be soon.
try the latest rc.

Change-Id: Iacc1280e4c6ada1bbd663180fe9ee37e23eb5520
