### PR TITLE
commands: add go.goroot command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -27,6 +27,10 @@ Finally, you can also see a full list by using a meta command: `Go: Show All Com
 
 See the currently set GOPATH.
 
+### `Go: Current GOROOT`
+
+See the currently set GOROOT.
+
 ### `Go: Locate Configured Go Tools`
 
 List all the Go tools being used by this extension along with their locations.

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "workspaceContains:*/*.go",
     "workspaceContains:*/*/*.go",
     "onCommand:go.gopath",
+    "onCommand:go.goroot",
     "onCommand:go.tools.install",
     "onCommand:go.locate.tools",
     "onCommand:go.show.commands",
@@ -210,6 +211,11 @@
         "command": "go.gopath",
         "title": "Go: Current GOPATH",
         "description": "See the currently set GOPATH."
+      },
+      {
+        "command": "go.goroot",
+        "title": "Go: Current GOROOT",
+        "description": "See the currently set GOROOT."
       },
       {
         "command": "go.locate.tools",

--- a/src/commands/getCurrentGoRoot.ts
+++ b/src/commands/getCurrentGoRoot.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------
+ * Copyright 2022 The Go Authors. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+import { CommandFactory } from '.';
+import { getCurrentGoRoot as utilGetCurrentGoRoot } from '../utils/pathUtils';
+
+export const getCurrentGoRoot: CommandFactory = () => {
+	return () => {
+		const goroot = utilGetCurrentGoRoot();
+		const msg = `${goroot} is the current GOROOT.`;
+		vscode.window.showInformationMessage(msg);
+		return goroot;
+	};
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -10,6 +10,7 @@ import { GoExtensionContext } from '../context';
 export { applyCoverprofile } from './applyCoverprofile';
 export { getConfiguredGoTools } from './getConfiguredGoTools';
 export { getCurrentGoPath } from './getCurrentGoPath';
+export { getCurrentGoRoot } from './getCurrentGoRoot';
 export { extractFunction, extractVariable } from '../goDoctor';
 export { runFillStruct } from '../goFillStruct';
 export { implCursor } from '../goImpl';

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -136,6 +136,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<ExtensionA
 	ctx.subscriptions.push(goCtx.vetDiagnosticCollection);
 
 	registerCommand('go.gopath', commands.getCurrentGoPath);
+	registerCommand('go.goroot', commands.getCurrentGoRoot);
 	registerCommand('go.locate.tools', commands.getConfiguredGoTools);
 	registerCommand('go.add.tags', commands.addTags);
 	registerCommand('go.remove.tags', commands.removeTags);


### PR DESCRIPTION
Add go.goroot command, similar to the existing go.gopath.

Closes golang/vscode-go#2379.