### PR TITLE
.github/workflows: fix wiki.yml

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-         go-version: '1.18'
+         go-version: '1.19'
          check-latest: true
          cache: true
 

--- a/.github/workflows/test-long-all.yml
+++ b/.github/workflows/test-long-all.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         version: ['stable', 'insiders']
-        go: ['1.16', '1.17', '1.18', '1.19.0-rc.2']
+        go: ['1.16', '1.17', '1.18', '1.19']
 
     steps:
       - name: Clone repository

--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest] # TODO: reenable macos-latest
         version: ['stable']
-        go: ['1.16', '1.17', '1.18', '1.19.0-rc.2']
+        go: ['1.16', '1.17', '1.18', '1.19']
 
     steps:
       - name: Clone repository

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-         go-version: '1.19.0-rc.2'
+         go-version: '1.19.0'
          check-latest: true
          cache: true
 

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -6,6 +6,7 @@ on:
     branches: [ master ]
     paths:
       - 'docs/**'
+      - '.github/workflows/wiki.yml'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 permissions:
@@ -37,6 +38,8 @@ jobs:
           go-version: '1.18'
           check-latest: true
           cache: true
+          cache-dependency-path: '**/go.sum'
+
       - name: Push to wiki
         run: |
           cd vscode-go

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
           check-latest: true
           cache: true
           cache-dependency-path: '**/go.sum'


### PR DESCRIPTION
wiki.yml workflow checks out both vscode-go and vscode-go.wiki repos.
This confuses actions/setup-go@v3 caching mechanism and we ended up
getting errors like

```
Dependencies file is not found in /home/runner/work/vscode-go/vscode-go.
Supported file pattern: go.sum
```
Tweak the configuration to search for go.sum files.

And trigger the workflow if this workflow file on master is changed.

Change-Id: I8762f1f21d1180b605431f400ead3cfe37bebf83