### PR TITLE
snippet/go.json: add code snippet for variable block

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,13 +69,13 @@ You can run `npm run lint` on the command-line to check for lint errors in your 
 
 ### Run
 
-To run the extension with your patch, open the Run view (`Ctrl+Shift+D`), select `Launch Extension`, and click the Play button (`F5`).
+To run the extension with your patch, open the Run view (`Ctrl+Shift+D` or `⌘+⇧+D`), select `Launch Extension`, and click the Play button (`F5`).
 
 This will open a new VS Code window with the title `[Extension Development Host]`. You can then open a folder that contains Go code and try out your changes.
 
 You can also set breakpoints to debug your change.
 
-If you make subsequent edits in the codebase, you can reload (`Ctrl+R`) the `[Extension Development Host]` instance of VS Code, which will load the new code. The debugger will automatically reattach.
+If you make subsequent edits in the codebase, you can reload (`Ctrl+R` or `⌘+R`) the `[Extension Development Host]` instance of VS Code, which will load the new code. The debugger will automatically reattach.
 
 ## Test
 

--- a/snippets/go.json
+++ b/snippets/go.json
@@ -45,10 +45,15 @@
 			"body": "func $1($2) $3 {\n\t$0\n}",
 			"description": "Snippet for function declaration"
 		},
-		"variable declaration": {
+		"single variable": {
 			"prefix": "var",
 			"body": "var ${1:name} ${2:type}",
 			"description": "Snippet for a variable"
+		},
+		"multiple variables": {
+			"prefix": "vars",
+			"body": "var (\n\t${1:name} ${2:type}\n)",
+			"description": "Snippet for variable block"
 		},
 		"switch statement": {
 			"prefix": "switch",


### PR DESCRIPTION
This PR adds a code snippet for creating a variable block. It also fixes running instructions for the mac in the contributing guide. 