### PR TITLE
src/goTest: add codelens for sub tests

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,6 +47,10 @@ Runs a unit test at the cursor if one is found, otherwise re-runs the last execu
 
 Runs a sub test at the cursor.
 
+### `Go: Debug Subtest At Cursor`
+
+Debug a sub test at the cursor.
+
 ### `Go: Benchmark Function At Cursor`
 
 Runs a benchmark at the cursor.

--- a/package.json
+++ b/package.json
@@ -239,6 +239,11 @@
         "description": "Runs a sub test at the cursor."
       },
       {
+        "command": "go.debug.subtest.cursor",
+        "title": "Go: Debug Subtest At Cursor",
+        "description": "Debug a sub test at the cursor."
+      },
+      {
         "command": "go.benchmark.cursor",
         "title": "Go: Benchmark Function At Cursor",
         "description": "Runs a benchmark at the cursor."

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -148,6 +148,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<ExtensionA
 	registerCommand('go.test.cursorOrPrevious', commands.testAtCursorOrPrevious('test'));
 	registerCommand('go.subtest.cursor', commands.subTestAtCursor('test'));
 	registerCommand('go.debug.cursor', commands.testAtCursor('debug'));
+	registerCommand('go.debug.subtest.cursor', commands.subTestAtCursor('debug'));
 	registerCommand('go.benchmark.cursor', commands.testAtCursor('benchmark'));
 	registerCommand('go.test.package', commands.testCurrentPackage(false));
 	registerCommand('go.benchmark.package', commands.testCurrentPackage(true));

--- a/src/goMain.ts
+++ b/src/goMain.ts
@@ -146,7 +146,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<ExtensionA
 	registerCommand('go.godoctor.var', commands.extractVariable);
 	registerCommand('go.test.cursor', commands.testAtCursor('test'));
 	registerCommand('go.test.cursorOrPrevious', commands.testAtCursorOrPrevious('test'));
-	registerCommand('go.subtest.cursor', commands.subTestAtCursor);
+	registerCommand('go.subtest.cursor', commands.subTestAtCursor('test'));
 	registerCommand('go.debug.cursor', commands.testAtCursor('debug'));
 	registerCommand('go.benchmark.cursor', commands.testAtCursor('benchmark'));
 	registerCommand('go.test.package', commands.testCurrentPackage(false));

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -102,32 +102,43 @@ export class GoRunTestCodeLensProvider extends GoBaseCodeLensProvider {
 				return codelens;
 			}
 
-			const addLens = (range: vscode.Range, functionName: string) => {
+			const simpleRunRegex = /t.Run\("([^"]+)",/;
+
+			for (const f of testFunctions) {
+				const functionName = f.name;
+
 				codelens.push(
-					new CodeLens(range, {
+					new CodeLens(f.range, {
 						title: 'run test',
 						command: 'go.test.cursor',
 						arguments: [{ functionName }]
 					}),
-					new CodeLens(range, {
+					new CodeLens(f.range, {
 						title: 'debug test',
 						command: 'go.debug.cursor',
 						arguments: [{ functionName }]
 					})
 				);
-			};
-
-			const simpleRunRegex = /t.Run\("([^"]+)",/;
-
-			for (const f of testFunctions) {
-				addLens(f.range, f.name);
 
 				for (let i = f.range.start.line; i < f.range.end.line; i++) {
 					const line = document.lineAt(i);
 					const simpleMatch = line.text.match(simpleRunRegex);
 
 					if (simpleMatch) {
-						addLens(line.range, f.name + '/' + simpleMatch[1]);
+						const subTestName = simpleMatch[1];
+
+						codelens.push(
+							new CodeLens(line.range, {
+								title: 'run test',
+								command: 'go.subtest.cursor',
+								arguments: [{ functionName, subTestName }]
+							}),
+							new CodeLens(line.range, {
+								title: 'debug test',
+								command: 'go.debug.subtest.cursor',
+								arguments: [{ functionName, subTestName }]
+							})
+						);
 					}
 				}
 			}

--- a/src/goRunTestCodelens.ts
+++ b/src/goRunTestCodelens.ts
@@ -124,6 +124,9 @@ export class GoRunTestCodeLensProvider extends GoBaseCodeLensProvider {
 					const line = document.lineAt(i);
 					const simpleMatch = line.text.match(simpleRunRegex);
 
+					// BUG: this does not handle nested subtests. This should
+					// be solved once codelens is handled by gopls and not by
+					// vscode.
 					if (simpleMatch) {
 						const subTestName = simpleMatch[1];
 

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -234,7 +234,7 @@ async function runTestAtCursor(
 export function subTestAtCursor(cmd: SubTestAtCursorCmd): CommandFactory {
 	return (_, goCtx) => async (args: string[]) => {
 		try {
-			await _subTestAtCursor(goCtx, getGoConfig(), cmd, args);
+			return await _subTestAtCursor(goCtx, getGoConfig(), cmd, args);
 		} catch (err) {
 			if (err instanceof NotFoundError) {
 				vscode.window.showInformationMessage(err.message);

--- a/src/goTest.ts
+++ b/src/goTest.ts
@@ -11,10 +11,10 @@ import { CommandFactory } from './commands';
 import { getGoConfig } from './config';
 import { GoExtensionContext } from './context';
 import { isModSupported } from './goModules';
+import { escapeSubTestName } from './subTestUtils';
 import {
 	extractInstanceTestName,
 	findAllTestSuiteRuns,
-	escapeSubTestName,
 	getBenchmarkFunctions,
 	getTestFlags,
 	getTestFunctionDebugArgs,

--- a/src/subTestUtils.ts
+++ b/src/subTestUtils.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------
+ * Copyright 2022 The Go Authors. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------*/
+
 /**
  * Escapes the subtest target name for the given test and subtest names.
  *

--- a/src/subTestUtils.ts
+++ b/src/subTestUtils.ts
@@ -1,0 +1,18 @@
+/**
+ * Escapes the subtest target name for the given test and subtest names.
+ *
+ * This function generates a name that matches a specific test by following Go
+ * regexp rules for `go test -run` argument. Specifically it escapes slashes,
+ * replaces whitespaces with underscores and wraps everything else with literal
+ * escape sequences.
+ *
+ * @param testFuncName Name of the parent test function, e.g. "TestTask"
+ * @param subTestName Name of the subtest, e.g. "GET /path/:id"
+ */
+export function escapeSubTestName(testFuncName: string, subTestName: string): string {
+	return `${testFuncName}/${subTestName}`
+		.replace(/\s/g, '_')
+		.split('/')
+		.map((part) => `\\Q${part}\\E`, '')
+		.join('$/^');
+}

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -654,3 +654,22 @@ export function importsTestify(syms: vscode.DocumentSymbol[]): boolean {
 			(sym.name === '"github.com/stretchr/testify/suite"' || sym.name === 'github.com/stretchr/testify/suite')
 	);
 }
+
+/**
+ * Escapes the subtest target name for the given test and subtest names.
+ *
+ * This function generates a name that matches a specific test by following Go
+ * regexp rules for `go test -run` argument. Specifically it escapes slashes,
+ * replaces whitespaces with underscores and wraps everything else with literal
+ * escape sequences.
+ *
+ * @param testFuncName Name of the parent test function, e.g. "TestTask"
+ * @param subTestName Name of the subtest, e.g. "GET /path/:id"
+ */
+export function escapeSubTestName(testFuncName: string, subTestName: string): string {
+	return `${testFuncName}/${subTestName}`
+		.replace(/\s/g, '_')
+		.split('/')
+		.map((part) => `\\Q${part}\\E`, '')
+		.join('$/^');
+}

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -654,22 +654,3 @@ export function importsTestify(syms: vscode.DocumentSymbol[]): boolean {
 			(sym.name === '"github.com/stretchr/testify/suite"' || sym.name === 'github.com/stretchr/testify/suite')
 	);
 }
-
-/**
- * Escapes the subtest target name for the given test and subtest names.
- *
- * This function generates a name that matches a specific test by following Go
- * regexp rules for `go test -run` argument. Specifically it escapes slashes,
- * replaces whitespaces with underscores and wraps everything else with literal
- * escape sequences.
- *
- * @param testFuncName Name of the parent test function, e.g. "TestTask"
- * @param subTestName Name of the subtest, e.g. "GET /path/:id"
- */
-export function escapeSubTestName(testFuncName: string, subTestName: string): string {
-	return `${testFuncName}/${subTestName}`
-		.replace(/\s/g, '_')
-		.split('/')
-		.map((part) => `\\Q${part}\\E`, '')
-		.join('$/^');
-}

--- a/test/integration/codelens.test.ts
+++ b/test/integration/codelens.test.ts
@@ -114,8 +114,17 @@ suite('Code lenses for testing and benchmarking', function () {
 
 	test('Test codelenses', async () => {
 		const codeLenses = await codeLensProvider.provideCodeLenses(document, cancellationTokenSource.token);
-		assert.equal(codeLenses.length, 4);
-		const wantCommands = ['go.test.package', 'go.test.file', 'go.test.cursor', 'go.debug.cursor'];
+		assert.equal(codeLenses.length, 8);
+		const wantCommands = [
+			'go.test.package',
+			'go.test.file',
+			'go.test.cursor',
+			'go.debug.cursor',
+			'go.subtest.cursor',
+			'go.debug.subtest.cursor',
+			'go.subtest.cursor',
+			'go.debug.subtest.cursor'
+		];
 		for (let i = 0; i < codeLenses.length; i++) {
 			assert.equal(codeLenses[i].command?.command, wantCommands[i]);
 		}

--- a/test/integration/codelens.test.ts
+++ b/test/integration/codelens.test.ts
@@ -64,21 +64,21 @@ suite('Code lenses for testing and benchmarking', function () {
 	test('Subtests - runs a test with cursor on t.Run line', async () => {
 		const editor = await vscode.window.showTextDocument(document);
 		editor.selection = new vscode.Selection(7, 4, 7, 4);
-		const result = await subTestAtCursor(ctx, {})([]);
+		const result = await subTestAtCursor('test')(ctx, {})([]);
 		assert.equal(result, true);
 	});
 
 	test('Subtests - runs a test with cursor within t.Run function', async () => {
 		const editor = await vscode.window.showTextDocument(document);
 		editor.selection = new vscode.Selection(8, 4, 8, 4);
-		const result = await subTestAtCursor(ctx, {})([]);
+		const result = await subTestAtCursor('test')(ctx, {})([]);
 		assert.equal(result, true);
 	});
 
 	test('Subtests - returns false for a failing test', async () => {
 		const editor = await vscode.window.showTextDocument(document);
 		editor.selection = new vscode.Selection(11, 4, 11, 4);
-		const result = await subTestAtCursor(ctx, {})([]);
+		const result = await subTestAtCursor('test')(ctx, {})([]);
 		assert.equal(result, false);
 	});
 
@@ -86,7 +86,7 @@ suite('Code lenses for testing and benchmarking', function () {
 		const editor = await vscode.window.showTextDocument(document);
 		editor.selection = new vscode.Selection(17, 4, 17, 4);
 		sinon.stub(vscode.window, 'showInputBox').onFirstCall().resolves(undefined);
-		const result = await subTestAtCursor(ctx, {})([]);
+		const result = await subTestAtCursor('test')(ctx, {})([]);
 		assert.equal(result, undefined);
 	});
 
@@ -94,21 +94,21 @@ suite('Code lenses for testing and benchmarking', function () {
 		const editor = await vscode.window.showTextDocument(document);
 		editor.selection = new vscode.Selection(17, 4, 17, 4);
 		sinon.stub(vscode.window, 'showInputBox').onFirstCall().resolves('dynamic test name');
-		const result = await subTestAtCursor(ctx, {})([]);
+		const result = await subTestAtCursor('test')(ctx, {})([]);
 		assert.equal(result, false);
 	});
 
 	test('Subtests - does nothing when cursor outside of a test function', async () => {
 		const editor = await vscode.window.showTextDocument(document);
 		editor.selection = new vscode.Selection(5, 0, 5, 0);
-		const result = await subTestAtCursor(ctx, {})([]);
+		const result = await subTestAtCursor('test')(ctx, {})([]);
 		assert.equal(result, undefined);
 	});
 
 	test('Subtests - does nothing when no test function covers the cursor and a function name is passed in', async () => {
 		const editor = await vscode.window.showTextDocument(document);
 		editor.selection = new vscode.Selection(5, 0, 5, 0);
-		const result = await subTestAtCursor(ctx, {})({ functionName: 'TestMyFunction' });
+		const result = await subTestAtCursor('test')(ctx, {})({ functionName: 'TestMyFunction' });
 		assert.equal(result, undefined);
 	});
 

--- a/test/unit/subTestUtils.test.ts
+++ b/test/unit/subTestUtils.test.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------
+ * Copyright 2022 The Go Authors. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------*/
+
 import assert from 'assert';
 import { escapeSubTestName } from '../../src/subTestUtils';
 

--- a/test/unit/subTestUtils.test.ts
+++ b/test/unit/subTestUtils.test.ts
@@ -1,0 +1,24 @@
+import assert from 'assert';
+import { escapeSubTestName } from '../../src/subTestUtils';
+
+suite.only('escapeSubTestName Tests', () => {
+	test('correctly escapes sub tests', () => {
+		const tt = [
+			{
+				test: 'TestFunction',
+				subtest: 'GET /path/with/slashes',
+				want: '\\QTestFunction\\E$/^\\QGET_\\E$/^\\Qpath\\E$/^\\Qwith\\E$/^\\Qslashes\\E'
+			},
+			{
+				test: 'TestMain',
+				subtest: 'All{0,1} tests [run]+ (fine)',
+				want: '\\QTestMain\\E$/^\\QAll{0,1}_tests_[run]+_(fine)\\E'
+			}
+		];
+
+		for (const tc of tt) {
+			const got = escapeSubTestName(tc.test, tc.subtest);
+			assert.strictEqual(got, tc.want);
+		}
+	});
+});

--- a/test/unit/subTestUtils.test.ts
+++ b/test/unit/subTestUtils.test.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { escapeSubTestName } from '../../src/subTestUtils';
 
-suite.only('escapeSubTestName Tests', () => {
+suite('escapeSubTestName Tests', () => {
 	test('correctly escapes sub tests', () => {
 		const tt = [
 			{


### PR DESCRIPTION
The current implementation did not support codelens for sub tests and this
made it quite cumbersome to test and debug codebases that use a large
number of subtests within vscode.

This pull request introduces:
- Test and debug codelenses support for subtests
- A new command "Go: Debug Subtest At Cursor"
- Fixes issues with subtests not running due to missing test name escaping

Fixes golang/vscode-go#2536 
