### PR TITLE
src/debugAdapter: handle missing variables gracefully

### DIFF
--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -2344,7 +2344,12 @@ export class GoDebugSession extends LoggingDebugSession {
 				variablesReference: 0
 			};
 		} else if (v.kind === GoReflectKind.Ptr) {
-			if (v.children[0].addr === 0) {
+			if (!v.children[0]) {
+				return {
+					result: 'gone <' + v.type + '>',
+					variablesReference: 0
+				};
+			} else if (v.children[0].addr === 0) {
 				return {
 					result: 'nil <' + v.type + '>',
 					variablesReference: 0

--- a/src/debugAdapter/goDebug.ts
+++ b/src/debugAdapter/goDebug.ts
@@ -2346,7 +2346,7 @@ export class GoDebugSession extends LoggingDebugSession {
 		} else if (v.kind === GoReflectKind.Ptr) {
 			if (!v.children[0]) {
 				return {
-					result: 'gone <' + v.type + '>',
+					result: 'unknown <' + v.type + '>',
 					variablesReference: 0
 				};
 			} else if (v.children[0].addr === 0) {


### PR DESCRIPTION
It seems that we might hit variables here that "exist" but do not have information for them at
all. Handle that case by reporting them as "gone".

Fixes golang/vscode-go#2397
