### PR TITLE
bump golangci-lint to v1.51.2 to fix false positive "Join not declared by package errors" with Golang 1.20.1

### DIFF
--- a/src/goToolsInformation.ts
+++ b/src/goToolsInformation.ts
@@ -192,7 +192,7 @@ export const allToolsInformation: { [key: string]: Tool } = {
 		replacedByGopls: false,
 		isImportant: true,
 		description: 'Linter',
-		defaultVersion: 'v1.51.0'
+		defaultVersion: 'v1.51.2'
 	},
 	'revive': {
 		name: 'revive',


### PR DESCRIPTION
v1.51.0 incorrectly flags uses of `errors.Join` with Go 1.20.1 in use.
