### PR TITLE
Add setting to limit indexing of the entire workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1475,6 +1475,12 @@
           "description": "Concatenate all test log messages for a given location into a single message.",
           "scope": "resource"
         },
+        "go.testExplorer.indexEntireWorkspace": {
+          "type": "boolean",
+          "default": true,
+          "description": "When searching for available tests, walk will include all packages in the workspace. If false, only tests in the current test file and package will be discovered.",
+          "scope": "resource"
+        },
         "go.testExplorer.showDynamicSubtestsInEditor": {
           "type": "boolean",
           "default": false,

--- a/src/goTest/explore.ts
+++ b/src/goTest/explore.ts
@@ -2,7 +2,6 @@
  * Copyright 2021 The Go Authors. All rights reserved.
  * Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------*/
-import path = require('path');
 import {
 	ConfigurationChangeEvent,
 	ExtensionContext,
@@ -259,16 +258,12 @@ export class GoTestExplorer {
 	}
 
 	protected async didCreateFile(file: Uri) {
-		// If not indexing the entire workspace, then handle newly created files only if the package is already present in the test explorer.
-		const pkg = GoTest.id(file.with({ path: path.dirname(file.path) }), 'package');
-		if (this.resolver.shouldIndexAll || this.resolver.all.get(pkg)) {
-			// Do not use openTextDocument to get the TextDocument for file,
-			// since this sends a didOpen text document notification to gopls,
-			// leading to spurious diagnostics from gopls:
-			// https://github.com/golang/vscode-go/issues/2570
-			// Instead, get the test item for this file only.
-			await this.resolver.getFile(file);
-		}
+		// Do not use openTextDocument to get the TextDocument for file,
+		// since this sends a didOpen text document notification to gopls,
+		// leading to spurious diagnostics from gopls:
+		// https://github.com/golang/vscode-go/issues/2570
+		// Instead, get the test item for this file only.
+		await this.resolver.processCreatedFile(file);
 	}
 
 	protected async didDeleteFile(file: Uri) {

--- a/src/goTest/resolve.ts
+++ b/src/goTest/resolve.ts
@@ -42,6 +42,7 @@ export class GoTestResolver {
 	public readonly isDynamicSubtest = new WeakSet<TestItem>();
 	public readonly isTestMethod = new WeakSet<TestItem>();
 	public readonly isTestSuiteFunc = new WeakSet<TestItem>();
+	public readonly shouldIndexAll = getGoConfig().get('testExplorer.indexEntireWorkspace');
 	private readonly testSuites = new Map<string, TestSuite>();
 
 	constructor(
@@ -82,7 +83,9 @@ export class GoTestResolver {
 				}
 			});
 
-			// Create entries for all modules and workspaces
+			if (!this.shouldIndexAll) return;
+
+			// Create entries for all modules and workspaces, if indexing the entire workspace.
 			for (const folder of this.workspace.workspaceFolders || []) {
 				const found = await walkWorkspaces(this.workspace.fs, folder.uri);
 				let needWorkspace = false;
@@ -107,7 +110,8 @@ export class GoTestResolver {
 
 		if (!item.uri) return;
 		// The user expanded a module or workspace - find all packages
-		if (kind === 'module' || kind === 'workspace') {
+		// Always skipped if not indexing the entire workspace
+		if ((kind === 'module' || kind === 'workspace') && this.shouldIndexAll) {
 			await walkPackages(this.workspace.fs, item.uri, async (uri) => {
 				await this.getPackage(uri);
 			});

--- a/src/goTest/resolve.ts
+++ b/src/goTest/resolve.ts
@@ -252,6 +252,14 @@ export class GoTestResolver {
 		return item;
 	}
 
+	public async processCreatedFile(uri: Uri): Promise<void> {
+		const pkg = GoTest.id(uri.with({ path: path.dirname(uri.path) }), 'package');
+
+		// If we are not indexing the entire workspace, process file only if its package is already part of the resolver.
+		// This prevents adding files that were created by Git in paths outside of those that are already indexed.
+		if (this.shouldIndexAll || this.all.get(pkg)) this.getFile(uri);
+	}
+
 	/* ***** Private ***** */
 
 	private shouldSetRange(item: TestItem): boolean {


### PR DESCRIPTION
This change adjusts test explorer to better support large repos, where a user will only want to see tests relevant to the file that they're working on.

Adds a new option, go.testExplorer.indexEntireWorkspace, which defaults to true for existing behavior.

If set to false, the functionality of the GoTestResolver will be adjusted to skip attempting to walk all packages, so the user will just see the tests indexed from within the current package where they are working.

Resolves golang/vscode-go#2504