### PR TITLE
package.json: update launch args schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -678,7 +678,7 @@
                 "default": false
               },
               "args": {
-                "type": "array",
+                "type": ["array", "string"],
                 "description": "Command line arguments passed to the debugged program.",
                 "items": {
                   "type": "string"


### PR DESCRIPTION
This is a follow-up change from https://github.com/golang/vscode-go/pull/2670 to update the schema. This avoids intellisense warning squiggly lines when updating `launch.json` while using a `string` type for `args`.

Validated by importing the local `.vsix` extension, and verifying no warnings show up for `string` and `array` args.

Fixes https://github.com/golang/vscode-go/issues/2621