### PR TITLE
src/goTest: fix display pprof result page when using ssh

### DIFF
--- a/src/goTest/profile.ts
+++ b/src/goTest/profile.ts
@@ -198,6 +198,8 @@ async function show(profile: string) {
 		proc.stderr.on('data', captureStdout);
 	});
 
+	const externalUri = await vscode.env.asExternalUri(vscode.Uri.parse(`http://localhost:${port}`));
+
 	const panel = vscode.window.createWebviewPanel('go.profile', 'Profile', ViewColumn.Active);
 	panel.webview.options = { enableScripts: true };
 	panel.webview.html = `<html>
@@ -217,7 +219,7 @@ async function show(profile: string) {
 			</style>
 		</head>
 		<body>
-			<iframe src="http://localhost:${port}"></iframe>
+			<iframe src="${externalUri}"></iframe>
 		</body>
 	</html>`;
 


### PR DESCRIPTION
It is not possible to open a web view directly through a local server. Pprof is launched by default via localhost on the remote server. This means that for a remotely running workspace extension, the webviews it creates would not be able to access local servers spawned by the extension.

After fix:
![image](https://github.com/golang/vscode-go/assets/19306721/2a193915-9145-4b0e-9f1f-531549e4bc31)

Pprof uses absolute references. This means it won't work for codespace, but this completely works for vscode. To fix it, need to change the page rendering in pprof.

Fixes #3090