### PR TITLE
src/goTest: fix multifile suite test fails to debug

### DIFF
--- a/extension/src/goTest/run.ts
+++ b/extension/src/goTest/run.ts
@@ -21,14 +21,7 @@ import vscode = require('vscode');
 import { outputChannel } from '../goStatus';
 import { isModSupported } from '../goModules';
 import { getGoConfig } from '../config';
-import {
-	getBenchmarkFunctions,
-	getTestFlags,
-	getSuiteToTestMap,
-	getTestFunctions,
-	goTest,
-	GoTestOutput
-} from '../testUtils';
+import { getTestFlags, getTestFunctionsAndTestSuite, goTest, GoTestOutput } from '../testUtils';
 import { GoTestResolver } from './resolve';
 import { dispose, forEachAsync, GoTest, Workspace } from './utils';
 import { GoTestProfiler, ProfilingOptions } from './profile';
@@ -168,9 +161,11 @@ export class GoTestRunner {
 		await doc.save();
 
 		const goConfig = getGoConfig(test.uri);
-		const getFunctions = kind === 'benchmark' ? getBenchmarkFunctions : getTestFunctions;
-		const testFunctions = await getFunctions(this.goCtx, doc, token);
-		const suiteToTest = await getSuiteToTestMap(this.goCtx, doc, token);
+		const { testFunctions, suiteToTest } = await getTestFunctionsAndTestSuite(
+			kind === 'benchmark',
+			this.goCtx,
+			doc
+		);
 
 		// TODO Can we get output from the debug session, in order to check for
 		// run/pass/fail events?

--- a/extension/src/testUtils.ts
+++ b/extension/src/testUtils.ts
@@ -11,6 +11,7 @@ import cp = require('child_process');
 import path = require('path');
 import util = require('util');
 import vscode = require('vscode');
+import { promises as fs } from 'fs';
 
 import { applyCodeCoverageToAllEditors } from './goCover';
 import { toolExecutionEnvironment } from './goEnv';
@@ -50,6 +51,7 @@ const testMethodRegex = /^\(([^)]+)\)\.(Test|Test\P{Ll}.*)$/u;
 const benchmarkRegex = /^Benchmark$|^Benchmark\P{Ll}.*/u;
 const fuzzFuncRegx = /^Fuzz$|^Fuzz\P{Ll}.*/u;
 const testMainRegex = /TestMain\(.*\*testing.M\)/;
+const runTestSuiteRegex = /^\s*suite\.Run\(\w+,\s*(?:&?(?<type1>\w+)\{|new\((?<type2>\w+)\))/mu;
 
 /**
  * Input to goTest.
@@ -164,7 +166,7 @@ export async function getTestFunctions(
 	}
 	const children = symbol.children;
 
-	// With gopls dymbol provider symbols, the symbols have the imports of all
+	// With gopls symbol provider, the symbols have the imports of all
 	// the package, so suite tests from all files will be found.
 	const testify = importsTestify(symbols);
 	return children.filter(
@@ -199,14 +201,15 @@ export function extractInstanceTestName(symbolName: string): string {
 export function getTestFunctionDebugArgs(
 	document: vscode.TextDocument,
 	testFunctionName: string,
-	testFunctions: vscode.DocumentSymbol[]
+	testFunctions: vscode.DocumentSymbol[],
+	suiteToFunc: SuiteToTestMap
 ): string[] {
 	if (benchmarkRegex.test(testFunctionName)) {
 		return ['-test.bench', '^' + testFunctionName + '$', '-test.run', 'a^'];
 	}
 	const instanceMethod = extractInstanceTestName(testFunctionName);
 	if (instanceMethod) {
-		const testFns = findAllTestSuiteRuns(document, testFunctions);
+		const testFns = findAllTestSuiteRuns(document, testFunctions, suiteToFunc);
 		const testSuiteRuns = ['-test.run', `^${testFns.map((t) => t.name).join('|')}$`];
 		const testSuiteTests = ['-testify.m', `^${instanceMethod}$`];
 		return [...testSuiteRuns, ...testSuiteTests];
@@ -222,12 +225,22 @@ export function getTestFunctionDebugArgs(
  */
 export function findAllTestSuiteRuns(
 	doc: vscode.TextDocument,
-	allTests: vscode.DocumentSymbol[]
+	allTests: vscode.DocumentSymbol[],
+	suiteToFunc: SuiteToTestMap
 ): vscode.DocumentSymbol[] {
-	// get non-instance test functions
-	const testFunctions = allTests?.filter((t) => !testMethodRegex.test(t.name));
-	// filter further to ones containing suite.Run()
-	return testFunctions?.filter((t) => doc.getText(t.range).includes('suite.Run(')) ?? [];
+	const suites = allTests
+		// Find all tests with receivers.
+		?.map((e) => e.name.match(testMethodRegex))
+		.filter((e) => e?.length === 3)
+		// Take out receiever, strip leading *.
+		.map((e) => e && e[1].replace(/^\*/g, ''))
+		// Map receiver name to test that runs "suite.Run".
+		.map((e) => e && suiteToFunc[e])
+		// Filter out empty results.
+		.filter((e): e is vscode.DocumentSymbol => !!e);
+
+	// Dedup.
+	return [...new Set(suites)];
 }
 
 /**
@@ -252,6 +265,59 @@ export async function getBenchmarkFunctions(
 	}
 	const children = symbol.children;
 	return children.filter((sym) => sym.kind === vscode.SymbolKind.Function && benchmarkRegex.test(sym.name));
+}
+
+export type SuiteToTestMap = Record<string, vscode.DocumentSymbol>;
+
+/**
+ * Returns a mapping between a package's function receivers to
+ * the test method that initiated them with "suite.Run".
+ *
+ * @param the URI of a Go source file.
+ * @return function symbols from all source files of the package, mapped by target suite names.
+ */
+export async function getSuiteToTestMap(
+	goCtx: GoExtensionContext,
+	doc: vscode.TextDocument,
+	token?: vscode.CancellationToken
+) {
+	// Get all the package documents.
+	const packageDir = path.parse(doc.fileName).dir;
+	const packageContent = await fs.readdir(packageDir, { withFileTypes: true });
+	const packageFilenames = packageContent
+		// Only go files.
+		.filter((dirent) => dirent.isFile())
+		.map((dirent) => dirent.name)
+		.filter((name) => name.endsWith('.go'));
+	const packageDocs = await Promise.all(
+		packageFilenames.map((e) => path.join(packageDir, e)).map(vscode.workspace.openTextDocument)
+	);
+
+	const suiteToTest: SuiteToTestMap = {};
+	for (const packageDoc of packageDocs) {
+		const funcs = await getTestFunctions(goCtx, packageDoc, token);
+		if (!funcs) {
+			continue;
+		}
+
+		for (const func of funcs) {
+			const funcText = packageDoc.getText(func.range);
+
+			// Matches run suites of the types:
+			// type1: suite.Run(t, MySuite{
+			// type1: suite.Run(t, &MySuite{
+			// type2: suite.Run(t, new(MySuite)
+			const matchRunSuite = funcText.match(runTestSuiteRegex);
+			if (!matchRunSuite) {
+				continue;
+			}
+
+			const g = matchRunSuite.groups;
+			suiteToTest[g?.type1 || g?.type2 || ''] = func;
+		}
+	}
+
+	return suiteToTest;
 }
 
 /**

--- a/extension/test/gopls/codelens.test.ts
+++ b/extension/test/gopls/codelens.test.ts
@@ -11,9 +11,10 @@ import sinon = require('sinon');
 import vscode = require('vscode');
 import { updateGoVarsFromConfig } from '../../src/goInstallTools';
 import { GoRunTestCodeLensProvider } from '../../src/goRunTestCodelens';
-import { subTestAtCursor } from '../../src/goTest';
+import { subTestAtCursor, testAtCursor } from '../../src/goTest';
 import { MockExtensionContext } from '../mocks/MockContext';
 import { Env } from './goplsTestEnv.utils';
+import * as testUtils from '../../src/testUtils';
 
 suite('Code lenses for testing and benchmarking', function () {
 	this.timeout(20000);
@@ -199,5 +200,142 @@ suite('Code lenses for testing and benchmarking', function () {
 		found.sort();
 		// Results should match `go test -list`.
 		assert.deepStrictEqual(found, ['TestNotMain']);
+	});
+
+	test('Debug - debugs a test with cursor on t.Run line', async () => {
+		const startDebuggingStub = sinon.stub(vscode.debug, 'startDebugging').returns(Promise.resolve(true));
+
+		const editor = await vscode.window.showTextDocument(document);
+		editor.selection = new vscode.Selection(7, 4, 7, 4);
+		const result = await subTestAtCursor('debug')(ctx, env.goCtx)([]);
+		assert.strictEqual(result, true);
+
+		assert.strictEqual(startDebuggingStub.callCount, 1, 'expected one call to startDebugging');
+		const gotConfig = startDebuggingStub.getCall(0).args[1] as vscode.DebugConfiguration;
+		gotConfig.program = '';
+		assert.deepStrictEqual<vscode.DebugConfiguration>(gotConfig, {
+			name: 'Debug Test',
+			type: 'go',
+			request: 'launch',
+			args: ['-test.run', '^TestSample$/^sample_test_passing$'],
+			buildFlags: '',
+			env: {},
+			sessionID: undefined,
+			mode: 'test',
+			envFile: null,
+			program: ''
+		});
+	});
+});
+
+suite('Code lenses with stretchr/testify/suite', function () {
+	const ctx = MockExtensionContext.new();
+
+	const testdataDir = path.join(__dirname, '..', '..', '..', 'test', 'testdata', 'stretchrTestSuite');
+	const env = new Env();
+
+	this.afterEach(async function () {
+		// Note: this shouldn't use () => {...}. Arrow functions do not have 'this'.
+		// I don't know why but this.currentTest.state does not have the expected value when
+		// used with teardown.
+		env.flushTrace(this.currentTest?.state === 'failed');
+		ctx.teardown();
+		sinon.restore();
+	});
+
+	suiteSetup(async () => {
+		await updateGoVarsFromConfig({});
+		await env.startGopls(undefined, undefined, testdataDir);
+	});
+
+	suiteTeardown(async () => {
+		await env.teardown();
+	});
+
+	test('Run test at cursor', async () => {
+		const goTestStub = sinon.stub(testUtils, 'goTest').returns(Promise.resolve(true));
+
+		const editor = await vscode.window.showTextDocument(vscode.Uri.file(path.join(testdataDir, 'suite_test.go')));
+		editor.selection = new vscode.Selection(25, 4, 25, 4);
+
+		const result = await testAtCursor('test')(ctx, env.goCtx)([]);
+		assert.strictEqual(result, true);
+
+		assert.strictEqual(goTestStub.callCount, 1, 'expected one call to goTest');
+		const gotConfig = goTestStub.getCall(0).args[0];
+		assert.deepStrictEqual(gotConfig.functions, ['(*ExampleTestSuite).TestExample', 'TestExampleTestSuite']);
+	});
+
+	test('Run test at cursor in different file than test suite definition', async () => {
+		const goTestStub = sinon.stub(testUtils, 'goTest').returns(Promise.resolve(true));
+
+		const editor = await vscode.window.showTextDocument(
+			vscode.Uri.file(path.join(testdataDir, 'another_suite_test.go'))
+		);
+		editor.selection = new vscode.Selection(3, 4, 3, 4);
+
+		const result = await testAtCursor('test')(ctx, env.goCtx)([]);
+		assert.strictEqual(result, true);
+
+		assert.strictEqual(goTestStub.callCount, 1, 'expected one call to goTest');
+		const gotConfig = goTestStub.getCall(0).args[0];
+		assert.deepStrictEqual(gotConfig.functions, [
+			'(*ExampleTestSuite).TestExampleInAnotherFile',
+			'TestExampleTestSuite'
+		]);
+	});
+
+	test('Debug test at cursor', async () => {
+		const startDebuggingStub = sinon.stub(vscode.debug, 'startDebugging').returns(Promise.resolve(true));
+
+		const editor = await vscode.window.showTextDocument(vscode.Uri.file(path.join(testdataDir, 'suite_test.go')));
+		editor.selection = new vscode.Selection(25, 4, 25, 4);
+
+		const result = await testAtCursor('debug')(ctx, env.goCtx)([]);
+		assert.strictEqual(result, true);
+
+		assert.strictEqual(startDebuggingStub.callCount, 1, 'expected one call to startDebugging');
+		const gotConfig = startDebuggingStub.getCall(0).args[1] as vscode.DebugConfiguration;
+		gotConfig.program = '';
+		assert.deepStrictEqual<vscode.DebugConfiguration>(gotConfig, {
+			name: 'Debug Test',
+			type: 'go',
+			request: 'launch',
+			args: ['-test.run', '^TestExampleTestSuite$/^TestExample$'],
+			buildFlags: '',
+			env: {},
+			sessionID: undefined,
+			mode: 'test',
+			envFile: null,
+			program: ''
+		});
+	});
+
+	test('Debug test at cursor in different file than test suite definition', async () => {
+		const startDebuggingStub = sinon.stub(vscode.debug, 'startDebugging').returns(Promise.resolve(true));
+
+		const editor = await vscode.window.showTextDocument(
+			vscode.Uri.file(path.join(testdataDir, 'another_suite_test.go'))
+		);
+		editor.selection = new vscode.Selection(3, 4, 3, 4);
+
+		const result = await testAtCursor('debug')(ctx, env.goCtx)([]);
+		assert.strictEqual(result, true);
+
+		assert.strictEqual(startDebuggingStub.callCount, 1, 'expected one call to startDebugging');
+		const gotConfig = startDebuggingStub.getCall(0).args[1] as vscode.DebugConfiguration;
+		gotConfig.program = '';
+		assert.deepStrictEqual<vscode.DebugConfiguration>(gotConfig, {
+			name: 'Debug Test',
+			type: 'go',
+			request: 'launch',
+			args: ['-test.run', '^TestExampleTestSuite$/^TestExampleInAnotherFile$'],
+			buildFlags: '',
+			env: {},
+			sessionID: undefined,
+			mode: 'test',
+			envFile: null,
+			program: ''
+		});
 	});
 });

--- a/extension/test/gopls/goTest.run.test.ts
+++ b/extension/test/gopls/goTest.run.test.ts
@@ -8,11 +8,16 @@ import { GoTestExplorer } from '../../src/goTest/explore';
 import { MockExtensionContext } from '../mocks/MockContext';
 import { GoTest } from '../../src/goTest/utils';
 import { Env } from './goplsTestEnv.utils';
+import { updateGoVarsFromConfig } from '../../src/goInstallTools';
 
 suite('Go Test Runner', () => {
 	const fixtureDir = path.join(__dirname, '..', '..', '..', 'test', 'testdata');
 
 	let testExplorer: GoTestExplorer;
+
+	suiteSetup(async () => {
+		await updateGoVarsFromConfig({});
+	});
 
 	suite('parseOutput', () => {
 		const ctx = MockExtensionContext.new();

--- a/extension/test/integration/test.test.ts
+++ b/extension/test/integration/test.test.ts
@@ -97,6 +97,19 @@ suite('Test Go Test Args', () => {
 			flags: ['-run', 'TestC']
 		});
 	});
+	test('use -testify.m for methods', () => {
+		runTest({
+			expectedArgs:
+				'test -timeout 30s -run ^TestExampleTestSuite$ -testify.m ^(TestExample|TestAnotherExample)$ ./...',
+			expectedOutArgs:
+				'test -timeout 30s -run ^TestExampleTestSuite$ -testify.m ^(TestExample|TestAnotherExample)$ ./...',
+			functions: [
+				'(*ExampleTestSuite).TestExample',
+				'(*ExampleTestSuite).TestAnotherExample',
+				'TestExampleTestSuite'
+			]
+		});
+	});
 });
 
 suite('Test Go Test', function () {

--- a/extension/test/testdata/stretchrTestSuite/another_suite_test.go
+++ b/extension/test/testdata/stretchrTestSuite/another_suite_test.go
@@ -1,0 +1,7 @@
+package main_test
+
+func (suite *ExampleTestSuite) TestExampleInAnotherFile() {
+	if suite.VariableThatShouldStartAtFive != 5 {
+		suite.T().Fatalf("%d != %d", 5, suite.VariableThatShouldStartAtFive)
+	}
+}

--- a/extension/test/testdata/stretchrTestSuite/go.mod
+++ b/extension/test/testdata/stretchrTestSuite/go.mod
@@ -1,10 +1,13 @@
 module example/a
 
-go 1.16
+go 1.21
+
+require github.com/stretchr/testify v1.7.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/stretchr/testify v1.7.0
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )


### PR DESCRIPTION
I have resumed the pull request golang/vscode-go#2415 and added the missing tests.

Here is the original description:

Collect a packages suites and maps their name with the caller function. This mapping is
used to fix a bug where vscode-go was formatting wrong arguments for dlv (-test.run).

Fixes golang/vscode-go#2414
