### PR TITLE
`func` -> `fu` |  func snippet/keyword conflict fix

### DIFF
--- a/extension/snippets/go.json
+++ b/extension/snippets/go.json
@@ -41,7 +41,7 @@
 			"description": "Snippet for main package & function"
 		},
 		"function declaration": {
-			"prefix": "func",
+			"prefix": "fu",
 			"body": "func $1($2) $3 {\n\t$0\n}",
 			"description": "Snippet for function declaration"
 		},


### PR DESCRIPTION
Vscode always selects the `func` keyword first. This is because the `func` snippet and the `func` keyword are the same. `"editor.snippetSuggestions":"top"`, even if selected.

## Before:

![Ekran Resmi 2024-01-20 16 01 28](https://github.com/golang/vscode-go/assets/36481442/4837394a-19b7-45c1-ae58-d398cefee5da)

## After:

![Ekran Resmi 2024-01-20 16 03 36](https://github.com/golang/vscode-go/assets/36481442/d9f37941-4b60-4300-805d-ce07c7f3c403)

