### PR TITLE
add the missing postfix `go.mod` to the grammar

### DIFF
--- a/extension/syntaxes/go.mod.tmGrammar.json
+++ b/extension/syntaxes/go.mod.tmGrammar.json
@@ -106,7 +106,7 @@
 					"name": "punctuation.definition.string.end.go.mod"
 				}
 			},
-			"name": "string.quoted.double",
+			"name": "string.quoted.double.go.mod",
 			"patterns": [
 				{
 					"include": "#string_escaped_char"
@@ -130,7 +130,7 @@
 					"name": "punctuation.definition.string.end.go.mod"
 				}
 			},
-			"name": "string.quoted.raw",
+			"name": "string.quoted.raw.go.mod",
 			"patterns": [
 				{
 					"include": "#string_placeholder"


### PR DESCRIPTION
This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `frob the quux before blarfing`
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes golang/vscode-go#1234` or `Updates golang/vscode-go#1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo, you can use the `owner/repo#issue_number` syntax:
  `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
