### PR TITLE
extension: customize build for tools

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -529,6 +529,21 @@ Default: `"proxy"`
 The path to the `go` binary used to install the Go tools. If it's empty, the same `go` binary chosen for the project will be used for tool installation.
 
 Default: `""`
+### `go.toolsManagement.buildEnvVars`
+
+Environment variables that will be used to install the Go tools.
+
+Default: `{}`
+### `go.toolsManagement.buildFlags`
+
+Flags to `go install` used to install the Go tools. (e.g. `["-ldflags", "-s -w"]`)
+
+Default: `[]`
+### `go.toolsManagement.buildTags`
+
+The Go build tags used to install the Go tools.
+
+Default: `""`
 ### `go.trace.server`
 
 Trace the communication between VS Code and the Go language server.<br/>

--- a/extension/package.json
+++ b/extension/package.json
@@ -1639,6 +1639,27 @@
           "description": "Automatically update the tools used by the extension, without prompting the user.",
           "scope": "resource"
         },
+        "go.toolsManagement.buildEnvVars": {
+          "type": "object",
+          "default": {},
+          "description": "Environment variables that will be used to install the Go tools.",
+          "scope": "machine-overridable"
+        },
+        "go.toolsManagement.buildFlags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Flags to `go install` used to install the Go tools. (e.g. [\"-ldflags\", \"-s -w\"])",
+          "scope": "machine-overridable"
+        },
+        "go.toolsManagement.buildTags": {
+          "type": "string",
+          "default": "",
+          "description": "The Go build tags used to install the Go tools.",
+          "scope": "machine-overridable"
+        },
         "go.enableCodeLens": {
           "type": "object",
           "properties": {

--- a/extension/src/goEnv.ts
+++ b/extension/src/goEnv.ts
@@ -45,7 +45,36 @@ export function toolInstallationEnvironment(): NodeJS.Dict<string> {
 	delete env['GOENV'];
 	delete env['GO111MODULE']; // we require module mode (default) for tools installation.
 
+	const toolsBuildEnv = getGoConfig().get('toolsManagement.buildEnvVars') ?? {};
+	if (toolsBuildEnv && typeof toolsBuildEnv === 'object') {
+		Object.keys(toolsBuildEnv).forEach(
+			(key) =>
+				(env[key] =
+					typeof toolsBuildEnv[key] === 'string'
+						? resolvePath(substituteEnv(toolsBuildEnv[key]))
+						: toolsBuildEnv[key])
+		);
+	}
+
 	return env;
+}
+
+export function toolInstallationArgs(buildArgs?: string[]): string[] {
+	const goConfig = getGoConfig();
+	const buildFlags: string[] = goConfig.get('toolsManagement.buildFlags') ?? [];
+	const buildTags: string = goConfig.get('toolsManagement.buildTags') ?? "";
+
+	const args: string[] = ['install'];
+	args.push(...buildFlags);
+	if (buildTags.length > 0 && buildFlags.indexOf('-tags') === -1) {
+		args.push('-tags');
+		args.push(buildTags);
+	}
+	if (buildArgs) {
+		args.push(...buildArgs);
+	}
+
+	return args;
 }
 
 // toolExecutionEnvironment returns the environment in which tools should

--- a/extension/src/goInstallTools.ts
+++ b/extension/src/goInstallTools.ts
@@ -14,7 +14,7 @@ import path = require('path');
 import semver = require('semver');
 import { ConfigurationTarget } from 'vscode';
 import { extensionInfo, getGoConfig, getGoplsConfig } from './config';
-import { toolExecutionEnvironment, toolInstallationEnvironment } from './goEnv';
+import { toolExecutionEnvironment, toolInstallationEnvironment, toolInstallationArgs } from './goEnv';
 import { addGoRuntimeBaseToPATH, clearGoRuntimeBaseFromPATH } from './goEnvironmentStatus';
 import { GoExtensionContext } from './context';
 import { addGoStatus, initGoStatusBar, outputChannel, removeGoStatus } from './goStatus';
@@ -372,9 +372,11 @@ async function installToolWithGoInstall(goVersion: GoVersion, env: NodeJS.Dict<s
 		cwd: getWorkspaceFolderPath()
 	};
 
+	const args: string[] = toolInstallationArgs(['-v', importPath]);
+
 	const execFile = util.promisify(cp.execFile);
 	outputChannel.trace(`${goBinary} install -v ${importPath} (cwd: ${opts.cwd})`);
-	await execFile(goBinary, ['install', '-v', importPath], opts);
+	await execFile(goBinary, args, opts);
 }
 
 export function declinedToolInstall(toolName: string): boolean {
@@ -1009,8 +1011,11 @@ export async function maybeInstallVSCGO(
 		if (!goBinary) {
 			throw new Error('"go" binary is not found');
 		}
-		const args = ['install', '-trimpath', `${importPath}${version}`];
-		console.log(`installing vscgo: ${args.join(' ')}`);
+
+		const originArgs: string[] = ['-trimpath', `${importPath}${version}`];
+		const args: string[] = toolInstallationArgs(originArgs);
+
+		console.log(`installing vscgo: install ${originArgs.join(' ')}`);
 		await execFile(goBinary, args, { cwd, env });
 		return progPath;
 	} catch (e) {


### PR DESCRIPTION
This change allows one to specify build settings used to install tools.

E.g. the one may specify "GOAMD64=v3" for tools (in order to match current
machine specs) but proceed with defaults (i.e. "GOAMD64=v1")
for builds/tests globally.