### PR TITLE
extension: run profile for coverage and coverage counts for files 

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -31,7 +31,7 @@
         "@types/node-fetch": "2.6.9",
         "@types/semver": "7.3.4",
         "@types/sinon": "9.0.11",
-        "@types/vscode": "1.75.0",
+        "@types/vscode": "1.88.0",
         "@vscode/debugadapter-testsupport": "1.58.0",
         "@vscode/test-electron": "2.3.8",
         "@vscode/vsce": "2.23.0",
@@ -718,9 +718,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
-      "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
+      "version": "1.88.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.88.0.tgz",
+      "integrity": "sha512-rWY+Bs6j/f1lvr8jqZTyp5arRMfovdxolcqGi+//+cPDOh8SBvzXH90e7BiSXct5HJ9HGW6jATchbRTpTJpEkw==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -5961,9 +5961,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
-      "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
+      "version": "1.88.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.88.0.tgz",
+      "integrity": "sha512-rWY+Bs6j/f1lvr8jqZTyp5arRMfovdxolcqGi+//+cPDOh8SBvzXH90e7BiSXct5HJ9HGW6jATchbRTpTJpEkw==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -75,7 +75,7 @@
     "@types/node-fetch": "2.6.9",
     "@types/semver": "7.3.4",
     "@types/sinon": "9.0.11",
-    "@types/vscode": "1.75.0",
+    "@types/vscode": "1.88.0",
     "@vscode/debugadapter-testsupport": "1.58.0",
     "@vscode/test-electron": "2.3.8",
     "@vscode/vsce": "2.23.0",

--- a/extension/src/goTest/run.ts
+++ b/extension/src/goTest/run.ts
@@ -129,6 +129,21 @@ export class GoTestRunner {
 			false
 		);
 
+		ctrl.createRunProfile(
+			'Go (Coverage)',
+			TestRunProfileKind.Coverage,
+			async (request, token) => {
+				try {
+					await this.run(request, token, {}, true);
+				} catch (error) {
+					const m = 'Failed to execute tests';
+					outputChannel.error(`${m}: ${error}`);
+					await vscode.window.showErrorMessage(m);
+				}
+			},
+			false
+		);
+
 		pprof.configureHandler = async () => {
 			const state = await this.profiler.configure();
 			if (!state) return;
@@ -228,7 +243,7 @@ export class GoTestRunner {
 	}
 
 	// Execute tests - TestController.runTest callback
-	async run(request: TestRunRequest, token?: CancellationToken, options: ProfilingOptions = {}): Promise<boolean> {
+	async run(request: TestRunRequest, token?: CancellationToken, options: ProfilingOptions = {}, applyCodeCoverage = false): Promise<boolean> {
 		const collected = new Map<TestItem, CollectedTest[]>();
 		const files = new Set<TestItem>();
 		if (request.include) {
@@ -360,7 +375,8 @@ export class GoTestRunner {
 				options,
 				pkg,
 				record,
-				concat
+				concat,
+				applyCodeCoverage,
 			};
 
 			// Run tests

--- a/extension/src/goTest/run.ts
+++ b/extension/src/goTest/run.ts
@@ -29,6 +29,7 @@ import { debugTestAtCursor } from '../goTest';
 import { GoExtensionContext } from '../context';
 import path = require('path');
 import { escapeRegExp } from '../subTestUtils';
+import { GetCoverageCounts } from '../goCover';
 
 let debugSessionID = 0;
 
@@ -408,6 +409,10 @@ export class GoTestRunner {
 			if (token?.isCancellationRequested) {
 				break;
 			}
+
+			if (applyCodeCoverage) {
+				this.collectCoverage(run);
+			}
 		}
 
 		run.end();
@@ -741,6 +746,19 @@ export class GoTestRunner {
 
 		// TODO(firelizzard18): Add more sophisticated check for build failures?
 		return output.some((x) => rePkg.test(x));
+	}
+
+	collectCoverage(run: TestRun) {
+		const coverageData = GetCoverageCounts();
+		for (const filename in coverageData) {
+			const data = coverageData[filename];
+			run.addCoverage(
+				new vscode.FileCoverage(
+					Uri.file(filename),
+					new vscode.TestCoverageCount(data.Covered, data.Total),
+				),
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds run profile for coverage and shows coverage counts for files.

<img width="1349" alt="Screenshot 2024-04-11 at 2 03 27" src="https://github.com/golang/vscode-go/assets/27106/cb618186-2747-4371-81df-bd571aff91ef">

[Fixes 3331](https://github.com/golang/vscode-go/issues/3331)