### PR TITLE
extension/package.json: edit default launch package dir

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -554,7 +554,7 @@
               "type": "go",
               "request": "launch",
               "mode": "auto",
-              "program": "^\"\\${fileDirname}${1:}\""
+              "program": "^\"\\${workspaceFolder}${1:}\""
             }
           },
           {


### PR DESCRIPTION
Edit .vscode/launch.json `Go: Launch package` template from `"program": "^\"\\${fileDirname}${1:}\""` to `"program": "^\"\\${workspaceFolder}${1:}\""`

Fixes golang/vscode-go#3387