### PR TITLE
Support go.testBinary to allow use of wrappers for testing

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -58,6 +58,10 @@ Alternate tools or alternate paths for the same tools used by the Go extension. 
 ### `go.buildFlags`
 
 Flags to `go build`/`go test` used during build-on-save or running tests. (e.g. ["-ldflags='-s'"]) This is propagated to the language server if `gopls.build.buildFlags` is not specified.
+### `go.testBinary`
+Alternative binary to use in place of `go` when calling `<bin> test`, in case you need have some additonal wrapper script needed for testing. Will be called instead of `go` so must support normal test args.
+
+
 ### `go.buildOnSave (deprecated)`
 
 Enable the Go language server (`#go.useLanguageServer#`) to diagnose compile errors.

--- a/extension/package.json
+++ b/extension/package.json
@@ -1560,6 +1560,12 @@
           "description": "Feature level setting to enable/disable code lens for references and run/debug tests",
           "scope": "resource"
         },
+        "go.testBinary": {
+          "type": "string",
+          "default": "",
+          "description": "The path to the test binary to use for running tests. If empty, the extension will use the default test binary.",
+          "scope": "resource"
+        },
         "go.addTags": {
           "type": "object",
           "properties": {

--- a/extension/src/testUtils.ts
+++ b/extension/src/testUtils.ts
@@ -144,6 +144,10 @@ export function getTestTags(goConfig: vscode.WorkspaceConfiguration): string {
 	return goConfig['testTags'] !== null ? goConfig['testTags'] : goConfig['buildTags'];
 }
 
+export function getTestGoBin(goConfig: vscode.WorkspaceConfiguration): string {
+	return goConfig['testBinary'];
+}
+
 /**
  * Returns all Go unit test functions in the given source file.
  *
@@ -425,10 +429,13 @@ export async function goTest(testconfig: TestConfig): Promise<boolean> {
 	outputChannel.appendLine('');
 
 	let testResult = false;
+
+	const testCmdBin = getTestGoBin(testconfig.goConfig);
+
 	try {
 		testResult = await new Promise<boolean>(async (resolve, reject) => {
 			const testEnvVars = getTestEnvVars(testconfig.goConfig);
-			const tp = cp.spawn(goRuntimePath, args, { env: testEnvVars, cwd: testconfig.dir });
+			const tp = cp.spawn(testCmdBin || goRuntimePath, args, { env: testEnvVars, cwd: testconfig.dir });
 			const outBuf = new LineBuffer();
 			const errBuf = new LineBuffer();
 


### PR DESCRIPTION
Add support for go.testBinary setting to allow for wrappers for tests

As mentioned in #3340 there are times when using `go` to execute tests is not possible, a wrapper is needed, this PR adds an new configuration `go.testBinary` where you would replace the go in `go test` with your declared binary

Fixes #3340
