### PR TITLE
upgrade packages impl and gomodifytags

### DIFF
--- a/extension/src/goToolsInformation.ts
+++ b/extension/src/goToolsInformation.ts
@@ -12,7 +12,7 @@ export const allToolsInformation: { [key: string]: Tool } = {
 		replacedByGopls: false,
 		isImportant: false,
 		description: 'Modify tags on structs',
-		defaultVersion: 'v1.16.0'
+		defaultVersion: 'v1.17.0'
 	},
 	'goplay': {
 		name: 'goplay',
@@ -30,7 +30,7 @@ export const allToolsInformation: { [key: string]: Tool } = {
 		replacedByGopls: false,
 		isImportant: false,
 		description: 'Stubs for interfaces',
-		defaultVersion: 'v1.1.0'
+		defaultVersion: 'v1.4.0'
 	},
 	'gofumpt': {
 		name: 'gofumpt',


### PR DESCRIPTION
Accumulative updates since:
```md
1 - `github.com/josharian/impl - v1.1.0`
 - [v1.2.0: avoid name collisions between receiver and params/results](https://github.com/josharian/impl/releases/tag/v1.2.0)
 - [v1.3.0: support generics](https://github.com/josharian/impl/releases/tag/v1.3.0)
 - [v1.4.0: Fix generation failure when multiple type parameters are in the receiver](https://github.com/josharian/impl/releases/tag/v1.4.0)


2 - `github.com/fatih/gomodifytags - v1.16.0`
 - [v1.17.0](https://github.com/fatih/gomodifytags/releases/tag/v1.17.0)
   - Update README.md by @laurixyz in https://github.com/fatih/gomodifytags/pull/90
   - Bump golang.org/x/tools from 0.0.0-20180824175216-6c1c5e93cdc1 to 0.6.0 by https://github.com/dependabot in https://github.com/fatih/gomodifytags/pull/97
   - Bump golang.org/x/tools from 0.6.0 to 0.7.0 by https://github.com/dependabot in https://github.com/fatih/gomodifytags/pull/98
   - chore: use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...)) by @testwill in https://github.com/fatih/gomodifytags/pull/106
   - add TextMate2 bundle link by @vigo in https://github.com/fatih/gomodifytags/pull/107
   - Dependency and CI updates by @fatih in https://github.com/fatih/gomodifytags/pull/112
   - Don't double up underscores with -transform=snakecase by @arp242 in https://github.com/fatih/gomodifytags/pull/96
 ```