### PR TITLE
settings: fix typo in templateExtensions description

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -610,7 +610,7 @@ This setting is only supported when gopls is built with Go 1.16 or later.
 Default: `["ignore"]`
 ### `build.templateExtensions`
 
-templateExtensions gives the extensions of file names that are treateed
+templateExtensions gives the extensions of file names that are treated
 as template files. (The extension
 is the part of the file name after the final dot.)
 


### PR DESCRIPTION
Corrected a typo in the "templateExtensions" description where "treateed" was mistakenly used instead of "treated". 

This PR improves the clarity of the documentation by fixing the typo in the settings description, ensuring accuracy for users.

This PR will be imported into Gerrit with the title and first comment (this text) used to generate the subject and body of the Gerrit change.

**Please ensure you adhere to every item in this list:**
- The PR title follows the format: `frob the quux before blarfing`
  - The verb tense + phrase should complete the sentence: "This change modifies Go to ___________"
  - Verb in lowercase
  - No trailing period
  - Title under 76 characters
- No Markdown in the commit message.
- The first PR comment (this one) is wrapped at 76 characters.
- If there is a corresponding issue, include either `Fixes golang/vscode-go#1234` or `Updates golang/vscode-go#1234` depending on whether this is a complete fix.
- Refer to repos using `owner/repo#issue_number` syntax when applicable.
- No `Signed-off-by` lines; CLA compliance is enforced by the bots.
