### PR TITLE
[master] fix open terminal on debug test when debug.internalConsoleOptions is set to neverOpen

### DIFF
--- a/extension/src/goTest.ts
+++ b/extension/src/goTest.ts
@@ -301,7 +301,9 @@ export async function debugTestAtCursor(
 	};
 	lastDebugConfig = debugConfig;
 	lastDebugWorkspaceFolder = workspaceFolder;
-	vscode.commands.executeCommand('workbench.debug.action.focusRepl');
+	if (vscode.workspace.getConfiguration().get('debug.internalConsoleOptions') !== 'neverOpen') {
+		vscode.commands.executeCommand('workbench.debug.action.focusRepl');
+	}
 	return await vscode.debug.startDebugging(workspaceFolder, debugConfig);
 }
 


### PR DESCRIPTION
fixes Microsoft/vscode#11372 (not vscode's bug, but of extension)