### PR TITLE
Snippets: remove the comma from the placeholder in `forr`

### DIFF
--- a/extension/snippets/go.json
+++ b/extension/snippets/go.json
@@ -77,7 +77,7 @@
 		},
 		"for range statement": {
 			"prefix": "forr",
-			"body": "for ${1:_, }${2:v} := range ${3:v} {\n\t$0\n}",
+			"body": "for ${1:_}, ${2:v} := range ${3:v} {\n\t$0\n}",
 			"description": "Snippet for a for range loop"
 		},
 		"channel declaration": {


### PR DESCRIPTION
When using "forr" snippet, 
the comma in the "_, " placeholder will be deleted 
if user edit the placeholder. 

So the comma should not be part of the placeholder