### PR TITLE
extension/src/goTest.ts: fix testFunctions filter

### DIFF
--- a/extension/src/goTest.ts
+++ b/extension/src/goTest.ts
@@ -100,7 +100,9 @@ async function _subTestAtCursor(
 	const { testFunctions, suiteToTest } = await getTestFunctionsAndTestSuite(false, goCtx, editor.document);
 	// We use functionName if it was provided as argument
 	// Otherwise find any test function containing the cursor.
-	const currentTestFunctions = testFunctions.filter((func) => func.range.contains(editor.selection.start));
+	const currentTestFunctions = args.functionName
+		? testFunctions.filter((func) => func.name === args.functionName)
+		: testFunctions.filter((func) => func.range.contains(editor.selection.start));
 	const testFunctionName =
 		args && args.functionName ? args.functionName : currentTestFunctions.map((el) => el.name)[0];
 


### PR DESCRIPTION
Add conditional filtering for test functions based on provided
function name in _subTestAtCursor

Using functionName if it was provided as argument, otherwise 
find any test function containing the cursor.

This change fixes a bug that previously required the cursor to be
within the parent function to run subtests. 
Now, subtests can be executed even if the cursor is not positioned
in the parent function.