### PR TITLE
golangci-lint: add support for v2

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -50,7 +50,7 @@
     "unit-test": "npm run test-compile && node ./node_modules/mocha/bin/_mocha -u tdd --timeout 5000 ./out/test/unit",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\""
   },
-  "extensionDependencies": [],
+  "extensionDependencies": [ ],
   "dependencies": {
     "diff": "4.0.2",
     "glob": "7.1.7",
@@ -610,7 +610,7 @@
         ],
         "configurationAttributes": {
           "launch": {
-            "required": [],
+            "required": [ ],
             "properties": {
               "debugAdapter": {
                 "enum": [
@@ -661,7 +661,7 @@
                 "items": {
                   "type": "string"
                 },
-                "default": []
+                "default": [ ]
               },
               "showLog": {
                 "type": "boolean",
@@ -676,7 +676,7 @@
               "env": {
                 "type": "object",
                 "description": "Environment variables passed to the launched debuggee program. Format as string key:value pairs. Merged with `envFile` and `go.toolsEnvVars` with precedence `env` > `envFile` > `go.toolsEnvVars`.",
-                "default": {}
+                "default": { }
               },
               "substitutePath": {
                 "type": "array",
@@ -696,7 +696,7 @@
                   }
                 },
                 "description": "An array of mappings from a local path (editor) to the remote path (debugee). This setting is useful when working in a file system with symbolic links, running remote debugging, or debugging an executable compiled externally. The debug adapter will replace the local path with the remote path in all of the calls.",
-                "default": []
+                "default": [ ]
               },
               "buildFlags": {
                 "type": [
@@ -707,7 +707,7 @@
                   "type": "string"
                 },
                 "description": "Build flags, to be passed to the Go compiler. Maps to dlv's `--build-flags` flag.",
-                "default": []
+                "default": [ ]
               },
               "dlvFlags": {
                 "type": "array",
@@ -715,7 +715,7 @@
                 "items": {
                   "type": "string"
                 },
-                "default": []
+                "default": [ ]
               },
               "port": {
                 "type": "number",
@@ -867,7 +867,7 @@
             }
           },
           "attach": {
-            "required": [],
+            "required": [ ],
             "properties": {
               "debugAdapter": {
                 "enum": [
@@ -916,7 +916,7 @@
                 "items": {
                   "type": "string"
                 },
-                "default": []
+                "default": [ ]
               },
               "showLog": {
                 "type": "boolean",
@@ -962,7 +962,7 @@
                   }
                 },
                 "description": "An array of mappings from a local path (editor) to the remote path (debugee). This setting is useful when working in a file system with symbolic links, running remote debugging, or debugging an executable compiled externally. The debug adapter will replace the local path with the remote path in all of the calls.  Overridden by `remotePath`.",
-                "default": []
+                "default": [ ]
               },
               "trace": {
                 "type": "string",
@@ -1116,7 +1116,7 @@
           "items": {
             "type": "string"
           },
-          "default": [],
+          "default": [ ],
           "description": "Flags to `go build`/`go test` used during build-on-save or running tests. (e.g. [\"-ldflags='-s'\"]) This is propagated to the language server if `gopls.build.buildFlags` is not specified.",
           "scope": "resource"
         },
@@ -1174,6 +1174,7 @@
             "staticcheck",
             "golint",
             "golangci-lint",
+            "golangci-lint-v2",
             "revive"
           ]
         },
@@ -1182,7 +1183,7 @@
           "items": {
             "type": "string"
           },
-          "default": [],
+          "default": [ ],
           "description": "Flags to pass to Lint tool (e.g. [\"-min_confidence=.8\"])",
           "scope": "resource"
         },
@@ -1207,7 +1208,7 @@
           "items": {
             "type": "string"
           },
-          "default": [],
+          "default": [ ],
           "description": "Flags to pass to `go tool vet` (e.g. [\"-all\", \"-shadow\"]). Not applicable when using the language server's diagnostics.",
           "scope": "resource"
         },
@@ -1238,7 +1239,7 @@
           "items": {
             "type": "string"
           },
-          "default": [],
+          "default": [ ],
           "description": "Flags to pass to format tool (e.g. [\"-s\"]). Not applicable when using the language server.",
           "scope": "resource"
         },
@@ -1415,7 +1416,7 @@
         },
         "go.testEnvVars": {
           "type": "object",
-          "default": {},
+          "default": { },
           "description": "Environment variables that will be passed to the process that runs the Go tests",
           "scope": "resource"
         },
@@ -1496,13 +1497,13 @@
           "items": {
             "type": "string"
           },
-          "default": [],
+          "default": [ ],
           "description": "Additional command line flags to pass to `gotests` for generating tests.",
           "scope": "resource"
         },
         "go.toolsEnvVars": {
           "type": "object",
-          "default": {},
+          "default": { },
           "description": "Environment variables that will be passed to the tools that run the Go tools (e.g. CGO_CFLAGS) and debuggee process launched by Delve. Format as string key:value pairs. When debugging, merged with `envFile` and `env` values with precedence `env` > `envFile` > `go.toolsEnvVars`.",
           "scope": "resource"
         },
@@ -1513,7 +1514,7 @@
         },
         "go.languageServerFlags": {
           "type": "array",
-          "default": [],
+          "default": [ ],
           "description": "Flags like -rpc.trace and -logfile to be used while running the language server."
         },
         "go.trace.server": {
@@ -1879,7 +1880,7 @@
               "items": {
                 "type": "string"
               },
-              "default": []
+              "default": [ ]
             },
             "substitutePath": {
               "type": "array",
@@ -1899,16 +1900,16 @@
                 }
               },
               "description": "An array of mappings from a local path to the remote path that is used by the debuggee. The debug adapter will replace the local path with the remote path in all of the calls. Overridden by `remotePath` (in attach request).",
-              "default": []
+              "default": [ ]
             }
           },
-          "default": {},
+          "default": { },
           "description": "Delve settings that applies to all debugging sessions. Debug configuration in the launch.json file will override these values.",
           "scope": "resource"
         },
         "go.alternateTools": {
           "type": "object",
-          "default": {},
+          "default": { },
           "description": "Alternate tools or alternate paths for the same tools used by the Go extension. Provide either absolute path or the name of the binary in GOPATH/bin, GOROOT/bin or PATH. Useful when you want to use wrapper script for the Go tools.",
           "scope": "resource",
           "properties": {
@@ -1955,7 +1956,7 @@
             "build.buildFlags": {
               "type": "array",
               "markdownDescription": "buildFlags is the set of flags passed on to the build system when invoked.\nIt is applied to queries like `go list`, which is used when discovering files.\nThe most common use is to set `-tags`.\n\nIf unspecified, values of `go.buildFlags, go.buildTags` will be propagated.\n",
-              "default": [],
+              "default": [ ],
               "scope": "resource"
             },
             "build.directoryFilters": {
@@ -1994,13 +1995,13 @@
             "build.templateExtensions": {
               "type": "array",
               "markdownDescription": "templateExtensions gives the extensions of file names that are treated\nas template files. (The extension\nis the part of the file name after the final dot.)\n",
-              "default": [],
+              "default": [ ],
               "scope": "resource"
             },
             "build.workspaceFiles": {
               "type": "array",
               "markdownDescription": "workspaceFiles configures the set of globs that match files defining the\nlogical build of the current workspace. Any on-disk changes to any files\nmatching a glob specified here will trigger a reload of the workspace.\n\nThis setting need only be customized in environments with a custom\nGOPACKAGESDRIVER.\n",
-              "default": [],
+              "default": [ ],
               "scope": "resource"
             },
             "formatting.gofumpt": {

--- a/extension/src/goLint.ts
+++ b/extension/src/goLint.ts
@@ -112,6 +112,7 @@ export function goLint(
 		}
 		args.push(flag);
 	});
+
 	if (lintTool === 'golangci-lint') {
 		if (args.indexOf('run') === -1) {
 			args.unshift('run');
@@ -124,6 +125,34 @@ export function goLint(
 			// print file:number:column.
 			// Explicit override in case .golangci.yml calls for a format we don't understand
 			args.push('--out-format=colored-line-number');
+		}
+		if (args.indexOf('--issues-exit-code=') === -1) {
+			// adds an explicit no-error-code return argument, to avoid npm error
+			// message detection logic. See golang/vscode-go/issues/411
+			args.push('--issues-exit-code=0');
+		}
+	}
+
+	if (lintTool === 'golangci-lint-v2') {
+		if (args.indexOf('run') === -1) {
+			args.unshift('run');
+		}
+		if (args.indexOf('--output.text.print-issued-lines') === -1) {
+			// print only file:number:column
+			args.push('--output.text.print-issued-lines=false');
+		}
+		if (args.indexOf('--output.text.colors') === -1) {
+			// print only file:number:column
+			args.push('--output.text.colors=true');
+		}
+		if (args.indexOf('--show-stats') === -1) {
+			// print only file:number:column
+			args.push('--show-stats=false');
+		}
+		if (args.indexOf('--output.text.path') === -1) {
+			// print file:number:column.
+			// Explicit override in case .golangci.yml calls for a format we don't understand
+			args.push('--output.text.path=stdout');
 		}
 		if (args.indexOf('--issues-exit-code=') === -1) {
 			// adds an explicit no-error-code return argument, to avoid npm error

--- a/extension/src/goLint.ts
+++ b/extension/src/goLint.ts
@@ -74,6 +74,8 @@ export function goLint(
 		return Promise.resolve([]);
 	}
 
+	console.log('goLint', lintTool, scope);
+
 	epoch++;
 	const closureEpoch = epoch;
 	if (tokenSource) {
@@ -159,6 +161,8 @@ export function goLint(
 			// message detection logic. See golang/vscode-go/issues/411
 			args.push('--issues-exit-code=0');
 		}
+
+		console.log('golangci-lint-v2', args);
 	}
 
 	if (scope === 'workspace' && currentWorkspace) {

--- a/extension/src/goTools.ts
+++ b/extension/src/goTools.ts
@@ -8,8 +8,8 @@
 
 import moment = require('moment');
 import semver = require('semver');
-import { getFormatTool, usingCustomFormatTool } from './language/legacy/goFormat';
 import { allToolsInformation } from './goToolsInformation';
+import { getFormatTool, usingCustomFormatTool } from './language/legacy/goFormat';
 import { GoVersion } from './util';
 
 export interface Tool {

--- a/extension/src/goToolsInformation.ts
+++ b/extension/src/goToolsInformation.ts
@@ -87,12 +87,11 @@ export const allToolsInformation: { [key: string]: Tool } = {
 	},
 	'golangci-lint-v2': {
 		name: 'golangci-lint-v2',
-		importPath: 'github.com/golangci/golangci-lint/cmd/golangci-lint',
+		importPath: 'github.com/golangci/golangci-lint/v2/cmd/golangci-lint',
 		modulePath: 'github.com/golangci/golangci-lint',
 		replacedByGopls: false,
 		isImportant: true,
-		description: 'Linter',
-		minimumGoVersion: semver.coerce('1.20')
+		description: 'Linter'
 	},
 	'revive': {
 		name: 'revive',

--- a/extension/src/goToolsInformation.ts
+++ b/extension/src/goToolsInformation.ts
@@ -85,6 +85,15 @@ export const allToolsInformation: { [key: string]: Tool } = {
 		description: 'Linter',
 		minimumGoVersion: semver.coerce('1.20')
 	},
+	'golangci-lint-v2': {
+		name: 'golangci-lint-v2',
+		importPath: 'github.com/golangci/golangci-lint/cmd/golangci-lint',
+		modulePath: 'github.com/golangci/golangci-lint',
+		replacedByGopls: false,
+		isImportant: true,
+		description: 'Linter',
+		minimumGoVersion: semver.coerce('1.20')
+	},
 	'revive': {
 		name: 'revive',
 		importPath: 'github.com/mgechev/revive',

--- a/extension/src/util.ts
+++ b/extension/src/util.ts
@@ -18,10 +18,10 @@ import { toolExecutionEnvironment } from './goEnv';
 import { outputChannel } from './goStatus';
 import { getFromWorkspaceState } from './stateUtils';
 import {
-	getEnvPath,
 	fixDriveCasingInWindows,
 	getBinPathWithPreferredGopathGorootWithExplanation,
 	getCurrentGoRoot,
+	getEnvPath,
 	getInferredGopath,
 	resolveHomeDir
 } from './utils/pathUtils';

--- a/extension/src/utils/pathUtils.ts
+++ b/extension/src/utils/pathUtils.ts
@@ -64,6 +64,11 @@ export function getBinPathWithPreferredGopathGorootWithExplanation(
 	alternateTool?: string,
 	useCache = true
 ): { binPath: string; why?: string } {
+	// fix for binname of golangci-lint when using v2
+	if (toolName === 'golangci-lint-v2') {
+		toolName = 'golangci-lint';
+	}
+
 	if (alternateTool && path.isAbsolute(alternateTool) && executableFileExists(alternateTool)) {
 		binPathCache[toolName] = alternateTool;
 		return { binPath: alternateTool, why: 'alternateTool' };


### PR DESCRIPTION
This PR adds support for `golangci-lint@v2` by adding a new lint tool called `golangci-lint-v2` to the list of supported options for linters. One limitation of this implementation is it does not support multiple versions of `golangci-lint` on the same machine. It also requires a manual override of the tool name.

Fixes #3732