### PR TITLE
extension/package.json: fix typo in debug/callstack/context

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -3472,7 +3472,7 @@
       "debug/callstack/context": [
         {
           "command": "go.debug.toggleHideSystemGoroutines",
-          "when": "debugType == 'go' && callStackItemType == 'stackFrame' || (callStackItemType == 'thread' && callStackItemStopped)"
+          "when": "debugType == 'go' && (callStackItemType == 'stackFrame' || (callStackItemType == 'thread' && callStackItemStopped))"
         }
       ],
       "editor/context": [


### PR DESCRIPTION
This patch fixes problem when user try debug not golang program, but see "Go: Toggle Hide System Goroutines" command menu item for threads in callstack view. 