### PR TITLE
extension: add debug menu for var show in doc

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -213,6 +213,10 @@
     },
     "commands": [
       {
+        "command": "go.debug.openVariableAsDoc",
+        "title": "Go: Open in new Document"
+      },
+      {
         "command": "go.gopath",
         "title": "Go: Current GOPATH",
         "description": "See the currently set GOPATH."
@@ -3488,6 +3492,13 @@
         {
           "command": "go.debug.toggleHideSystemGoroutines",
           "when": "debugType == 'go' && callStackItemType == 'stackFrame' || (callStackItemType == 'thread' && callStackItemStopped)"
+        }
+      ],
+      "debug/variables/context": [
+        {
+          "command": "go.debug.openVariableAsDoc",
+          "when": "debugType=='go'",
+          "group": "navigation"
         }
       ],
       "editor/context": [

--- a/extension/src/goDebugCommands.ts
+++ b/extension/src/goDebugCommands.ts
@@ -1,0 +1,41 @@
+import * as vscode from 'vscode';
+
+export function registerGoDebugCommands(ctx: vscode.ExtensionContext) {
+	ctx.subscriptions.push(
+		vscode.commands.registerCommand(
+			'go.debug.openVariableAsDoc',
+			async (args: any) => {
+				const variable = args.variable;
+
+				let raw = variable.value.trim();
+				if (
+					(raw.startsWith('"') && raw.endsWith('"')) ||
+					(raw.startsWith('`') && raw.endsWith('`'))
+				) {
+					raw = raw.slice(1, -1);
+				}
+
+				let text: string;
+				try {
+					text = JSON.parse(`"${raw.replace(/"/g, '\\"')}"`);
+				} catch {
+					text = raw
+						.replace(/\\r/g, '\r')
+						.replace(/\\n/g, '\n')
+						.replace(/\\t/g, '\t')
+						.replace(/\\"/g, '"')
+						.replace(/\\\\/g, '\\');
+				}
+
+				const doc = await vscode.workspace.openTextDocument({
+					language: 'plaintext',
+					content: text
+				});
+
+				const editor = await vscode.window.showTextDocument(doc);
+
+				await vscode.commands.executeCommand('workbench.action.editor.changeLanguageMode');
+			}
+		)
+	)
+}

--- a/extension/src/goDebugConfiguration.ts
+++ b/extension/src/goDebugConfiguration.ts
@@ -34,6 +34,7 @@ import { resolveHomeDir } from './utils/pathUtils';
 import { createRegisterCommand } from './commands';
 import { GoExtensionContext } from './context';
 import { spawn } from 'child_process';
+import { registerGoDebugCommands } from './goDebugCommands';
 
 let dlvDAPVersionChecked = false;
 
@@ -45,6 +46,7 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 		const registerCommand = createRegisterCommand(ctx, goCtx);
 		registerCommand('go.debug.pickProcess', () => pickProcess);
 		registerCommand('go.debug.pickGoProcess', () => pickGoProcess);
+		registerGoDebugCommands(ctx);
 	}
 
 	constructor(private defaultDebugAdapterType: string = 'go') {}


### PR DESCRIPTION
Adds a context-menu entry in the Variables views that opens the selected string value in a new editor tab, rendering real newlines instead of escape sequences.

Fixes golang/vscode-go#3817

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `frob the quux before blarfing`
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes golang/vscode-go#1234` or `Updates golang/vscode-go#1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo, you can use the `owner/repo#issue_number` syntax:
  `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
