### PR TITLE
goTest: Implement compatibility for test suite sub-tests

### DIFF
--- a/extension/src/goTest.ts
+++ b/extension/src/goTest.ts
@@ -44,7 +44,7 @@ async function _testAtCursor(
 	goCtx: GoExtensionContext,
 	goConfig: vscode.WorkspaceConfiguration,
 	cmd: TestAtCursorCmd,
-	args: any
+	args?: SubTestAtCursorArgs
 ) {
 	const editor = vscode.window.activeTextEditor;
 	if (!editor) {
@@ -72,7 +72,7 @@ async function _testAtCursor(
 	await editor.document.save();
 
 	if (cmd === 'debug') {
-		return debugTestAtCursor(editor, testFunctionName, testFunctions, suiteToTest, goConfig);
+		return debugTestAtCursor(editor, testFunctionName, testFunctions, suiteToTest, goConfig, undefined, args);
 	} else if (cmd === 'benchmark' || cmd === 'test') {
 		return runTestAtCursor(editor, testFunctionName, testFunctions, suiteToTest, goConfig, cmd, args);
 	} else {
@@ -165,7 +165,7 @@ async function _subTestAtCursor(
 	const escapedName = escapeSubTestName(testFunctionName, subTestName);
 
 	if (cmd === 'debug') {
-		return debugTestAtCursor(editor, escapedName, testFunctions, suiteToTest, goConfig);
+		return debugTestAtCursor(editor, escapedName, testFunctions, suiteToTest, goConfig, undefined, args);
 	} else if (cmd === 'test') {
 		return runTestAtCursor(editor, escapedName, testFunctions, suiteToTest, goConfig, cmd, args);
 	} else {
@@ -308,10 +308,11 @@ export async function debugTestAtCursor(
 	testFunctions: vscode.DocumentSymbol[],
 	suiteToFunc: SuiteToTestMap,
 	goConfig: vscode.WorkspaceConfiguration,
-	sessionID?: string
+	sessionID?: string,
+	testArgs?: { isTestSuite?: boolean },
 ) {
 	const doc = 'document' in editorOrDocument ? editorOrDocument.document : editorOrDocument;
-	const args = getTestFunctionDebugArgs(doc, testFunctionName, testFunctions, suiteToFunc);
+	const args = getTestFunctionDebugArgs(doc, testFunctionName, testFunctions, suiteToFunc, testArgs?.isTestSuite);
 	const tags = getTestTags(goConfig);
 	const buildFlags = tags ? ['-tags', tags] : [];
 	const flagsFromConfig = getTestFlags(goConfig);

--- a/extension/src/goTest.ts
+++ b/extension/src/goTest.ts
@@ -117,7 +117,7 @@ async function _subTestAtCursor(
 	// We use functionName if it was provided as argument
 	// Otherwise find any test function containing the cursor.
 	const currentTestFunctions = args?.functionName
-		? testFunctions.filter((func) => func.name === args.functionName)
+		? testFunctions.filter((func) => func.name.endsWith(String(args.functionName)))
 		: testFunctions.filter((func) => func.range.contains(editor.selection.start));
 	const testFunctionName =
 		args && args.functionName ? args.functionName : currentTestFunctions.map((el) => el.name)[0];
@@ -226,6 +226,10 @@ type TestAtCursor = {
 	 * Flags to be passed to `go test`.
 	 */
 	flags?: string[];
+	/**
+	 * Whether it's a test suite.
+	 */
+	isTestSuite?: boolean;
 };
 
 /**
@@ -252,6 +256,7 @@ async function runTestAtCursor(
 		flags: getTestFlags(goConfig, args),
 		functions: testConfigFns,
 		isBenchmark: cmd === 'benchmark',
+		isTestSuite: !!args?.isTestSuite,
 		isMod,
 		applyCodeCoverage: goConfig.get<boolean>('coverOnSingleTest')
 	};
@@ -273,10 +278,10 @@ export function subTestAtCursor(cmd: SubTestAtCursorCmd): CommandFactory {
 		 * codelens provided by {@link GoRunTestCodeLensProvider}, args
 		 * specifies the function and subtest names.
 		 */
-		args?: [SubTestAtCursorArgs]
+		args?:SubTestAtCursorArgs
 	) => {
 		try {
-			return await _subTestAtCursor(goCtx, getGoConfig(), cmd, args?.[0]);
+			return await _subTestAtCursor(goCtx, getGoConfig(), cmd, args);
 		} catch (err) {
 			if (err instanceof NotFoundError) {
 				vscode.window.showInformationMessage(err.message);

--- a/extension/src/testUtils.ts
+++ b/extension/src/testUtils.ts
@@ -250,12 +250,14 @@ export function extractInstanceTestName(symbolName: string): string {
  * @param document  The document containing the tests
  * @param testFunctionName The test function to get the debug args
  * @param testFunctions The test functions found in the document
+ * @param isTestSuite Indicator if the test function is part of a test suite
  */
 export function getTestFunctionDebugArgs(
 	document: vscode.TextDocument,
 	testFunctionName: string,
 	testFunctions: vscode.DocumentSymbol[],
-	suiteToFunc: SuiteToTestMap
+	suiteToFunc: SuiteToTestMap,
+	isTestSuite ?: boolean,
 ): string[] {
 	if (benchmarkRegex.test(testFunctionName)) {
 		return ['-test.bench', '^' + testFunctionName + '$', '-test.run', 'a^'];
@@ -265,7 +267,7 @@ export function getTestFunctionDebugArgs(
 		const testFns = findAllTestSuiteRuns(document, testFunctions, suiteToFunc);
 		return ['-test.run', `^${testFns.map((t) => t.name).join('|')}$/^${instanceMethod}$`];
 	} else {
-		return ['-test.run', `^${testFunctionName}$`];
+		return ['-test.run', `${!!isTestSuite ? '/': ''}^${testFunctionName}$`];
 	}
 }
 /**

--- a/extension/src/testUtils.ts
+++ b/extension/src/testUtils.ts
@@ -86,6 +86,10 @@ export interface TestConfig {
 	 */
 	isBenchmark?: boolean;
 	/**
+	 * Whether this is a test suite
+	 */
+	isTestSuite?: boolean;
+	/**
 	 * Whether the tests are being run in a project that uses Go modules
 	 */
 	isMod?: boolean;
@@ -736,7 +740,14 @@ function targetArgs(testconfig: TestConfig): Array<string> {
 			// which will result in the correct thing to happen
 			if (testFunctions.length > 0) {
 				if (testFunctions.length === 1) {
-					params = params.concat(['-run', util.format('^%s$', testFunctions[0])]);
+					// If it's a test suite, it means the test function is not a root test function.
+					// By prepending '/', the command will interpret and execute all child test functions
+					// that matches the pattern of anyTestSuite/givenFunctionName/givenCaseName.
+					if (testconfig.isTestSuite) {
+						params = params.concat(['-run', util.format('/^%s$', testFunctions[0])]);
+					} else {
+						params = params.concat(['-run', util.format('^%s$', testFunctions[0])]);
+					}
 				} else {
 					params = params.concat(['-run', util.format('^(%s)$', testFunctions.join('|'))]);
 				}


### PR DESCRIPTION
goTest: Implement compatibility for test suite sub-tests

* Increase regex compatibility for test suites and its sub-tests
  * Changes regex to search for any root test suite functions that matches the function name and sub-test name
  * Also contains a fix for debugging
  * I noticed some incompatibility between funcName sanitization and some pre-existing regexes for test suite detection
* Fix CodeLen args propagation ( it was passed as undefined before )
  * Allows to run test functions and sub tests without having cursor inside

These changes are just hotfixes for the suite detection bug that is still present in the codebase.
I would require further help to identify the issue behind the existent test suite detection problems with the regexes.

Fixes golang/vscode-go#3725