### PR TITLE
extension/src/utils: Support exported environment variables with go.testEnvFile

### DIFF
--- a/extension/test/integration/goDebugConfiguration.test.ts
+++ b/extension/test/integration/goDebugConfiguration.test.ts
@@ -130,7 +130,7 @@ suite('Debug Environment Variable Merge Test', () => {
 	test('launchArgs.env overwrites launchArgs.envFile', () => {
 		const env = { SOMEVAR1: 'valueFromEnv' };
 		const envFile = path.join(tmpDir, 'env');
-		fs.writeFileSync(envFile, ['SOMEVAR1=valueFromEnvFile1', 'SOMEVAR2=valueFromEnvFile2'].join('\n'));
+		fs.writeFileSync(envFile, ['SOMEVAR1=valueFromEnvFile1', 'export SOMEVAR2=valueFromEnvFile2'].join('\n'));
 
 		runTest(
 			{ env, envFile },


### PR DESCRIPTION
This changes adds support for exported environment variables in environment files with the go.testEnvFile configuration option

Fixes golang/vscode-go#3879
