### PR TITLE
Prompts to enter name of subtest of Table Driven Tests

### DIFF
--- a/extension/src/goRunTestCodelens.ts
+++ b/extension/src/goRunTestCodelens.ts
@@ -109,7 +109,7 @@ export class GoRunTestCodeLensProvider extends GoBaseCodeLensProvider {
 				return codelens;
 			}
 
-			const simpleRunRegex = /t.Run\("([^"]+)",/;
+			const simpleRunRegex = /t.Run\(/;
 
 			for (const f of testFunctions) {
 				const functionName = f.name;


### PR DESCRIPTION
This change modifies Go to run subtests of table-driven tests. With the fix, a prompt will appear for the user to enter the name of the subtest they wish to run.

Fixes golang/vscode-go#3962