### PR TITLE
fix: apply shell integration for environment variables

### DIFF
--- a/extension/src/goEnvironmentStatus.ts
+++ b/extension/src/goEnvironmentStatus.ts
@@ -364,11 +364,7 @@ export function addGoRuntimeBaseToPATH(newGoRuntimeBase: string) {
 			}
 			terminalCreationListener = vscode.window.onDidOpenTerminal(updateIntegratedTerminal);
 		} else {
-			environmentVariableCollection?.prepend(
-				pathEnvVar,
-				newGoRuntimeBase + path.delimiter,
-				envVarMutatorOptions
-			);
+			environmentVariableCollection?.prepend(pathEnvVar, newGoRuntimeBase + path.delimiter, envVarMutatorOptions);
 		}
 	}
 


### PR DESCRIPTION
Apply shell integration to ensure extension environment variables
like PATH take precedence over user exports in shell startup files.

Fixes golang/vscode-go#3975