### PR TITLE
snippets: add forrval snippet for single-variable range loops

### DIFF
--- a/extension/snippets/go.json
+++ b/extension/snippets/go.json
@@ -80,6 +80,11 @@
 			"body": "for ${1:_}, ${2:v} := range ${3:v} {\n\t$0\n}",
 			"description": "Snippet for a for range loop"
 		},
+		"for range channel statement": {
+			"prefix": "forrch",
+			"body": "for ${1:v} := range ${2:v} {\n\t$0\n}",
+			"description": "Snippet for a for range loop with single variable (channel)"
+		},
 		"channel declaration": {
 			"prefix": "ch",
 			"body": "chan ${1:type}",

--- a/extension/snippets/go.json
+++ b/extension/snippets/go.json
@@ -80,10 +80,10 @@
 			"body": "for ${1:_}, ${2:v} := range ${3:v} {\n\t$0\n}",
 			"description": "Snippet for a for range loop"
 		},
-		"for range channel statement": {
-			"prefix": "forrch",
+		"for range single var statement": {
+			"prefix": "forrval",
 			"body": "for ${1:v} := range ${2:v} {\n\t$0\n}",
-			"description": "Snippet for a for range loop with single variable (channel)"
+			"description": "Snippet for a for range loop with single variable (e.g. channel)"
 		},
 		"channel declaration": {
 			"prefix": "ch",


### PR DESCRIPTION
Add a new snippet, forrval, that generates a for-range loop with a single variable, commonly used with channels and, in Go 1.23+, for value-only iteration over slices and maps.

The snippet expands to:

for v := range v {
}



Updates golang/vscode-go#4026
