### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/test-long-all.yml
+++ b/.github/workflows/test-long-all.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 11 * * *"  # 11 UTC, everyday
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.os }} ${{ matrix.version }} ${{ matrix.go }}

--- a/.github/workflows/test-long.yml
+++ b/.github/workflows/test-long.yml
@@ -2,6 +2,9 @@ name: Long Tests
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.os }} ${{ matrix.version }} ${{ matrix.go }}

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -2,6 +2,9 @@ name: Smoke Tests
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.os }} ${{ matrix.version }}


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.