### PR TITLE
extension/src/goTest: preserve buildFlags as array when debugging tests

### DIFF
--- a/extension/src/goTest.ts
+++ b/extension/src/goTest.ts
@@ -335,9 +335,12 @@ export async function debugTestAtCursor(
 		env: goConfig.get('testEnvVars', {}),
 		envFile: goConfig.get('testEnvFile'),
 		args,
-		buildFlags: buildFlags.join(' '),
 		sessionID
 	};
+	// Keep as array; joining here corrupts flag values that contain spaces (e.g. -ldflags '-X k=v').
+	if (buildFlags.length > 0) {
+		debugConfig.buildFlags = buildFlags;
+	}
 	lastDebugConfig = debugConfig;
 	lastDebugWorkspaceFolder = workspaceFolder;
 	if (vscode.workspace.getConfiguration().get('debug.internalConsoleOptions') !== 'neverOpen') {

--- a/extension/test/gopls/codelens.test.ts
+++ b/extension/test/gopls/codelens.test.ts
@@ -15,6 +15,8 @@ import { subTestAtCursor, testAtCursor } from '../../src/goTest';
 import { MockExtensionContext } from '../mocks/MockContext';
 import { Env } from './goplsTestEnv.utils';
 import * as testUtils from '../../src/testUtils';
+import * as config from '../../src/config';
+import { MockCfg } from '../mocks/MockCfg';
 
 suite('Code lenses for testing and benchmarking', function () {
 	this.timeout(20000);
@@ -223,7 +225,6 @@ suite('Code lenses for testing and benchmarking', function () {
 			type: 'go',
 			request: 'launch',
 			args: ['-test.run', '^TestSample$/^sample_test_passing$'],
-			buildFlags: '',
 			env: {},
 			sessionID: undefined,
 			mode: 'test',
@@ -309,7 +310,6 @@ suite('Code lenses with stretchr/testify/suite', function () {
 			type: 'go',
 			request: 'launch',
 			args: ['-test.run', '^TestExampleTestSuite$/^TestExample$'],
-			buildFlags: '',
 			env: {},
 			sessionID: undefined,
 			mode: 'test',
@@ -337,12 +337,32 @@ suite('Code lenses with stretchr/testify/suite', function () {
 			type: 'go',
 			request: 'launch',
 			args: ['-test.run', '^TestExampleTestSuite$/^TestExampleInAnotherFile$'],
-			buildFlags: '',
 			env: {},
 			sessionID: undefined,
 			mode: 'test',
 			envFile: null,
 			program: ''
 		});
+	});
+
+	// Regression test for golang/vscode-go#3933: build flag values that contain spaces
+	// (e.g. -ldflags "-X k=v") must be passed as an array so delve sees each flag as a
+	// separate argument. Joining them into a single string corrupts the value.
+	test('Debug test at cursor preserves buildFlags as array', async () => {
+		const goConfig = new MockCfg({
+			buildFlags: ['-ldflags', '-X github.com/org/pkg/info.version=v25.8.0']
+		});
+		sinon.stub(config, 'getGoConfig').returns(goConfig);
+		const startDebuggingStub = sinon.stub(vscode.debug, 'startDebugging').returns(Promise.resolve(true));
+
+		const editor = await vscode.window.showTextDocument(vscode.Uri.file(path.join(testdataDir, 'suite_test.go')));
+		editor.selection = new vscode.Selection(25, 4, 25, 4);
+
+		const result = await testAtCursor('debug')(ctx, env.goCtx)([]);
+		assert.strictEqual(result, true);
+
+		assert.strictEqual(startDebuggingStub.callCount, 1, 'expected one call to startDebugging');
+		const gotConfig = startDebuggingStub.getCall(0).args[1] as vscode.DebugConfiguration;
+		assert.deepStrictEqual(gotConfig.buildFlags, ['-ldflags', '-X github.com/org/pkg/info.version=v25.8.0']);
 	});
 });


### PR DESCRIPTION
The debugTestAtCursor CodeLens previously joined go.buildFlags into a
single space-separated string before passing them to the debug adapter.
This corrupted flag values that contain spaces, such as
-ldflags "-X pkg.version=v1.0": after joining, delve sees -X and
pkg.version=v1.0 as separate arguments and fails with "with multiple
packages, -o must refer to a directory or /dev/null".

Meanwhile, the run-test CodeLens passes each flag as a separate
argument to go test, so the same go.buildFlags worked for "run test"
but broke "debug test".

Fix:
Pass buildFlags as an array to startDebugging. The existing
maybeJoinFlags helper in goDebugConfiguration.ts already handles both
shapes: it joins for delve < 1.22.2 and preserves the array for newer
delve, so each element reaches delve as a separate token. Also omit
buildFlags from the debug config when empty to keep behavior parity
with the previous "" sentinel.

Fixes golang/vscode-go#3933