### PR TITLE
extension/src: consider diagnostic severity when deduplicating

### DIFF
--- a/extension/src/util.ts
+++ b/extension/src/util.ts
@@ -700,14 +700,24 @@ export function removeDuplicateDiagnostics(
 
 /**
  * Removes any diagnostics in otherDiagnostics, where there is a diagnostic in
- * buildDiagnostics on the same line.
+ * buildDiagnostics on the same line that has equal or higher severity.
  */
 function deDupeDiagnostics(
 	buildDiagnostics: vscode.Diagnostic[],
 	otherDiagnostics: vscode.Diagnostic[]
 ): vscode.Diagnostic[] {
-	const buildDiagnosticsLines = buildDiagnostics.map((x) => x.range.start.line);
-	return otherDiagnostics.filter((x) => buildDiagnosticsLines.indexOf(x.range.start.line) === -1);
+	return otherDiagnostics.filter((otherDiag) => {
+		const otherLine = otherDiag.range.start.line;
+		const otherSeverity = otherDiag.severity ?? vscode.DiagnosticSeverity.Error;
+		const shouldDrop = buildDiagnostics.some((buildDiag) => {
+			if (buildDiag.range.start.line !== otherLine) {
+				return false;
+			}
+			const buildSeverity = buildDiag.severity ?? vscode.DiagnosticSeverity.Error;
+			return buildSeverity <= otherSeverity;
+		});
+		return !shouldDrop;
+	});
 }
 
 function mapSeverityToVSCodeSeverity(sev: string): vscode.DiagnosticSeverity {


### PR DESCRIPTION
Currently, deDupeDiagnostics removes diagnostics from other tools
(like golangci-lint) when there is a diagnostic from gopls on the
same line. This can cause high-severity diagnostics (e.g. errcheck
errors) to be silently dropped if a lower-severity gopls warning
(e.g. a staticcheck warning) exists on the same line.

Modify deDupeDiagnostics to only drop an external diagnostic when
the gopls diagnostic on the same line has equal or higher severity.
This ensures that higher-severity errors are no longer masked by
lower-severity warnings, while still avoiding duplicate warnings
for the same issue from different sources.

Updates golang/vscode-go#3511