### PR TITLE
src/goInstallTools: update default gofumpt version

### DIFF
--- a/extension/src/goTools.ts
+++ b/extension/src/goTools.ts
@@ -89,6 +89,9 @@ export function getImportPathWithVersion(
 		if (goVersion.lt('1.19')) return importPath + '@v0.4.0'; // pre-go1.19
 		if (goVersion.lt('1.20')) return importPath + '@v0.5.0'; // go1.19
 		if (goVersion.lt('1.22')) return importPath + '@v0.6.0'; // go1.20~1.21
+		if (goVersion.lt('1.23')) return importPath + '@v0.7.0'; // go1.22
+		if (goVersion.lt('1.24')) return importPath + '@v0.8.0'; // go1.23
+		if (goVersion.lt('1.25')) return importPath + '@v0.9.0'; // go1.24
 	}
 	if (tool.name === 'golangci-lint') {
 		if (goVersion.lt('1.20')) return importPath + '@v1.53.3';

--- a/extension/src/goToolsInformation.ts
+++ b/extension/src/goToolsInformation.ts
@@ -38,7 +38,7 @@ const internal = new Map<string, Tool>([
 			replacedByGopls: false,
 			isImportant: false,
 			description: 'Formatter',
-			defaultVersion: 'v0.7.0'
+			defaultVersion: 'v0.10.0'
 		}
 	],
 	[

--- a/extension/test/integration/install.test.ts
+++ b/extension/test/integration/install.test.ts
@@ -251,7 +251,7 @@ suite('Installation Tests', function () {
 			[{ name: 'gofumpt', versions: ['v0.4.7', 'v0.5.0', gofumptDefault], wantVersion: gofumptDefault }],
 			true, // LOCAL PROXY
 			true, // GOBIN
-			'go1.23.0' // Go Version
+			'go1.25' // Go Version
 		);
 	});
 

--- a/extension/tools/allTools.ts.in
+++ b/extension/tools/allTools.ts.in
@@ -36,7 +36,7 @@ const internal = new Map<string, Tool>([
 			replacedByGopls: false,
 			isImportant: false,
 			description: 'Formatter',
-			defaultVersion: 'v0.7.0'
+			defaultVersion: 'v0.10.0'
 		}
 	],
 	[


### PR DESCRIPTION
Bump the default installation version of the gofumpt formatter to 
v0.10.0 (which requires Go 1.25+).

Because gofumpt releases are tightly coupled to Go language versions, 
it also updates the fallback logic in goTools.ts to seamlessly handle 
older local Go versions by installing the appropriate legacy version of gofumpt.
Updated defaultVersion of gofumpt from v0.7.0 to v0.10.0.

Added missing fallback logic in goTools.ts for users running older Go versions:
* Go < 1.25 falls back to v0.9.0
* Go < 1.24 falls back to v0.8.0
* Go < 1.23 falls back to v0.7.0
* (Existing fallbacks for Go < 1.22 remain intact)