### PR TITLE
src/goInstallTools: update revive to v1.15.0

### DIFF
--- a/extension/src/goToolsInformation.ts
+++ b/extension/src/goToolsInformation.ts
@@ -120,7 +120,7 @@ const internal = new Map<string, Tool>([
 			modulePath: 'github.com/mgechev/revive',
 			isImportant: true,
 			description: 'Linter',
-			defaultVersion: 'v1.3.9'
+			defaultVersion: 'v1.15.0'
 		}
 	],
 	[

--- a/extension/tools/allTools.ts.in
+++ b/extension/tools/allTools.ts.in
@@ -118,7 +118,7 @@ const internal = new Map<string, Tool>([
 			modulePath: 'github.com/mgechev/revive',
 			isImportant: true,
 			description: 'Linter',
-			defaultVersion: 'v1.3.9'
+			defaultVersion: 'v1.15.0'
 		}
 	],
 	[


### PR DESCRIPTION
Update the default version of the revive tool
from v1.3.9 to v1.15.0