### PR TITLE
extension/src/goTest: skip testdata directories in test discovery

### DIFF
--- a/extension/src/goTest/resolve.ts
+++ b/extension/src/goTest/resolve.ts
@@ -208,6 +208,11 @@ export class GoTestResolver {
 	// the file will be disposed. If the document contains no tests, it will be
 	// disposed.
 	async processDocument(doc: TextDocument, ranges?: Range[]) {
+		// Don't resolve tests from files inside a testdata directory. The go
+		// command treats testdata as inert, and walkPackages already skips it,
+		// but a user can still open such a file directly.
+		if (isInTestdata(doc.uri)) return;
+
 		const seen = new Set<string>();
 		const item = await this.getFile(doc.uri);
 		const symbols = await this.provideDocumentSymbols(doc);
@@ -495,6 +500,11 @@ export class GoTestResolver {
 			}
 		}
 	}
+}
+
+// Reports whether the URI is inside a directory named 'testdata'.
+function isInTestdata(uri: Uri): boolean {
+	return uri.path.split('/').includes('testdata');
 }
 
 // Walk the workspace, looking for Go modules. Returns a map indicating paths

--- a/extension/src/goTest/walk.ts
+++ b/extension/src/goTest/walk.ts
@@ -43,6 +43,12 @@ export async function walk(
 					continue;
 				}
 
+				// Ignore testdata directories. The go command treats them as
+				// inert, so they never hold packages or tests we care about.
+				if (type === vscode.FileType.Directory && file === 'testdata') {
+					continue;
+				}
+
 				if (type === vscode.FileType.Directory) {
 					dirs2.push(vscode.Uri.joinPath(uri, file));
 				}

--- a/extension/test/gopls/goTest.resolve.test.ts
+++ b/extension/test/gopls/goTest.resolve.test.ts
@@ -115,6 +115,17 @@ suite('Go Test Resolver', () => {
 					'file:///src/proj/foo/bar?package',
 					'file:///src/proj/main_test.go?file'
 				]
+			},
+			'Skips testdata': {
+				workspace: ['/src/proj'],
+				files: {
+					'/src/proj/go.mod': 'module test',
+					'/src/proj/foo/main_test.go': 'package main',
+					'/src/proj/testdata/main_test.go': 'package main',
+					'/src/proj/foo/testdata/nested_test.go': 'package main'
+				},
+				item: [['test', '/src/proj', 'module']],
+				expect: ['file:///src/proj/foo?package']
 			}
 		},
 		Package: {
@@ -193,6 +204,22 @@ suite('Go Test Resolver', () => {
 					'file:///src/proj/main_test.go?example#ExampleBaz',
 					'file:///src/proj/main_test.go?fuzz#FuzzFuss'
 				]
+			},
+			'In testdata': {
+				workspace: ['/src/proj'],
+				files: {
+					'/src/proj/go.mod': 'module test',
+					'/src/proj/testdata/main_test.go': `
+						package main
+
+						func TestFoo(*testing.T) {}
+					`
+				},
+				item: [
+					['test', '/src/proj', 'module'],
+					['main_test.go', '/src/proj/testdata/main_test.go', 'file']
+				],
+				expect: []
 			}
 		}
 	};


### PR DESCRIPTION
The Test Explorer walks the workspace to discover _test.go files, but it
descended into testdata directories too. The go command treats testdata
as inert, so tests defined there aren't real and shouldn't appear in the
tree.

walk now skips directories named testdata, which keeps both walkWorkspaces
and walkPackages from descending into them. That covers discovery through
the tree, but a user can still open a _test.go file that lives under a
testdata directory directly, so processDocument returns early when the
document's path contains a testdata segment. This follows the approach
firelizzard18 outlined on the issue.

Added resolver tests for both paths: a testdata package is skipped during
module resolution, and a file opened from within testdata resolves no
tests.

Fixes golang/vscode-go#1854