### PR TITLE
src/goDebugConfiguration: skip program validation for external adapters

### DIFF
--- a/extension/src/goDebugConfiguration.ts
+++ b/extension/src/goDebugConfiguration.ts
@@ -528,7 +528,15 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 			//    because we do not control the adapter's launch process.
 			if (debugConfiguration.request === 'launch') {
 				const mode = debugConfiguration['mode'] || 'debug';
-				if (['debug', 'test', 'auto'].includes(mode)) {
+				if (
+					['debug', 'test', 'auto'].includes(mode) &&
+					// Presence of the following attributes indicates an externally launched
+					// debug adapter (e.g. a remote `dlv dap` server). The program lives on the
+					// remote and we do not control the adapter's launch process, so skip the
+					// local program validation and massaging entirely.
+					!debugConfiguration.port &&
+					!debugConfiguration.debugServer
+				) {
 					// Massage config to build the target from the package directory
 					// with a relative path. (https://github.com/golang/vscode-go/issues/1713)
 					// parseDebugProgramArgSync will throw an error if `program` is invalid.
@@ -536,13 +544,7 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 						debugConfiguration['program'],
 						folder?.uri.fsPath
 					);
-					if (
-						dirname &&
-						// Presence of the following attributes indicates externally launched debug adapter.
-						// Don't mess with 'program' if the debug adapter was launched externally.
-						!debugConfiguration.port &&
-						!debugConfiguration.debugServer
-					) {
+					if (dirname) {
 						debugConfiguration['__buildDir'] = dirname;
 						debugConfiguration['program'] = programIsDirectory
 							? '.'

--- a/extension/test/integration/goDebugConfiguration.test.ts
+++ b/extension/test/integration/goDebugConfiguration.test.ts
@@ -659,6 +659,32 @@ suite('Debug Configuration With Invalid Program', () => {
 			debugConfigProvider.resolveDebugConfigurationWithSubstitutedVariables(workspaceFolder, config);
 		}, /The program attribute.* must be a valid directory or .go file/);
 	});
+
+	test('program is not validated locally when connecting to an external dlv dap server (port)', () => {
+		// With 'port' set, the debug adapter is launched externally and the
+		// program lives on the remote, so it must not be validated locally.
+		const config = { ...debugConfig('dlv-dap'), program: '/notexists', port: 12345 };
+		const workspaceFolder = {
+			uri: vscode.Uri.file(workspaceDir),
+			name: 'test',
+			index: 0
+		};
+		assert.doesNotThrow(() => {
+			debugConfigProvider.resolveDebugConfigurationWithSubstitutedVariables(workspaceFolder, config);
+		});
+	});
+
+	test('program is not validated locally with an external debug adapter (debugServer)', () => {
+		const config = { ...debugConfig('dlv-dap'), program: '/notexists', debugServer: 4711 };
+		const workspaceFolder = {
+			uri: vscode.Uri.file(workspaceDir),
+			name: 'test',
+			index: 0
+		};
+		assert.doesNotThrow(() => {
+			debugConfigProvider.resolveDebugConfigurationWithSubstitutedVariables(workspaceFolder, config);
+		});
+	});
 });
 
 suite('Debug Configuration Converts Relative Paths', () => {


### PR DESCRIPTION
When launching debug/test/auto modes against an externally launched debug
adapter (a remote "dlv dap" server selected with "port", or
"debugServer"), the program lives on the remote and is resolved by that
adapter. resolveDebugConfigurationWithSubstitutedVariables still called
parseDebugProgramArgSync unconditionally, which lstats the program locally
and throws "The program attribute ... must be a valid directory or .go
file", breaking remote debugging.

Move the existing port/debugServer guard ahead of the call so the local
program validation and __buildDir massaging are skipped for externally
launched adapters, matching the intent already stated in the surrounding
comment.

Fixes golang/vscode-go#2698