### PR TITLE
debug: support alternate dlv batch files on Windows

### DIFF
--- a/extension/src/debugAdapter/goDebug.ts
+++ b/extension/src/debugAdapter/goDebug.ts
@@ -41,7 +41,8 @@ import {
 	fixDriveCasingInWindows,
 	getBinPathWithPreferredGopathGoroot,
 	getCurrentGoWorkspaceFromGOPATH,
-	getInferredGopath
+	getInferredGopath,
+	getToolSpawnCommand
 } from '../utils/pathUtils';
 import { killProcessTree } from '../utils/processUtils';
 
@@ -721,10 +722,12 @@ export class Delve {
 
 			log(`Current working directory: ${dlvCwd}`);
 			log(`Running: ${launchArgs.dlvToolPath} ${dlvArgs.join(' ')}`);
+			const dlvSpawn = getToolSpawnCommand(launchArgs.dlvToolPath);
 
-			this.debugProcess = spawn(launchArgs.dlvToolPath, dlvArgs, {
+			this.debugProcess = spawn(dlvSpawn.command, dlvArgs, {
 				cwd: dlvCwd,
-				env
+				env,
+				shell: dlvSpawn.shell
 			});
 
 			function connectClient(port: number, host: string, onClose?: Delve['onclose']) {

--- a/extension/src/goDebugConfiguration.ts
+++ b/extension/src/goDebugConfiguration.ts
@@ -29,7 +29,7 @@ import { getFromGlobalState, updateGlobalState } from './stateUtils';
 import { getBinPath, getGoVersion } from './util';
 import { parseArgsString } from './utils/argsUtil';
 import { parseEnvFiles } from './utils/envUtils';
-import { resolveHomeDir } from './utils/pathUtils';
+import { getToolSpawnCommand, resolveHomeDir } from './utils/pathUtils';
 import { createRegisterCommand } from './commands';
 import { GoExtensionContext } from './context';
 import { spawn } from 'child_process';
@@ -390,7 +390,9 @@ export class GoDebugConfigurationProvider implements vscode.DebugConfigurationPr
 	 */
 	async guessSubstitutePath(): Promise<object | null> {
 		return new Promise((resolve) => {
-			const child = spawn(getBinPath('dlv'), ['substitute-path-guess-helper']);
+			const dlvPath = getBinPath('dlv');
+			const dlvSpawn = getToolSpawnCommand(dlvPath);
+			const child = spawn(dlvSpawn.command, ['substitute-path-guess-helper'], { shell: dlvSpawn.shell });
 			let stdoutData = '';
 			child.stdout.on('data', (data) => {
 				stdoutData += data;

--- a/extension/src/goDebugFactory.ts
+++ b/extension/src/goDebugFactory.ts
@@ -13,7 +13,7 @@ import * as fs from 'fs';
 import * as net from 'net';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { getWorkspaceFolderPath } from './util';
-import { getEnvPath, getBinPathFromEnvVar } from './utils/pathUtils';
+import { getEnvPath, getBinPathFromEnvVar, getToolSpawnCommand } from './utils/pathUtils';
 import { GoExtensionContext } from './context';
 import { createRegisterCommand } from './commands';
 
@@ -539,15 +539,17 @@ function spawnDlvDapServerProcess(
 	const logDestStream = logDest ? fs.createWriteStream(logDest) : undefined;
 
 	logConsole(`Starting: ${dlvPath} ${dlvArgs.join(' ')} from ${dir}\n`);
+	const dlvSpawn = getToolSpawnCommand(dlvPath);
 
 	// TODO(hyangah): In module-module workspace mode, the program should be build in the super module directory
 	// where go.work (gopls.mod) file is present. Where dlv runs determines the build directory currently. Two options:
 	//  1) launch dlv in the super-module module directory and adjust launchArgs.cwd (--wd).
 	//  2) introduce a new buildDir launch attribute.
 	return new Promise<ChildProcess>((resolve, reject) => {
-		const p = spawn(dlvPath, dlvArgs, {
+		const p = spawn(dlvSpawn.command, dlvArgs, {
 			cwd: dir,
 			env: envForSpawn,
+			shell: dlvSpawn.shell,
 			stdio: onWindows ? ['pipe', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe', 'pipe'] // --log-dest=3 if !onWindows.
 		});
 		let started = false;

--- a/extension/src/utils/pathUtils.ts
+++ b/extension/src/utils/pathUtils.ts
@@ -151,6 +151,16 @@ export function correctBinname(toolName: string) {
 	return toolName;
 }
 
+// Windows batch files must be run through a shell. Quote the path because
+// child_process.spawn does not do so when the shell option is enabled.
+export function getToolSpawnCommand(
+	filePath: string,
+	platform = process.platform
+): { command: string; shell: boolean } {
+	const shell = platform === 'win32' && /\.(bat|cmd)$/i.test(filePath);
+	return { command: shell ? `"${filePath}"` : filePath, shell };
+}
+
 export function executableFileExists(filePath: string): boolean {
 	let exists = true;
 	try {

--- a/extension/test/integration/goDebug.test.ts
+++ b/extension/test/integration/goDebug.test.ts
@@ -23,9 +23,11 @@ import * as extConfig from '../../src/config';
 import { GoDebugConfigurationProvider, parseDebugProgramArgSync } from '../../src/goDebugConfiguration';
 import { getBinPath, rmdirRecursive } from '../../src/util';
 import { killProcessTree } from '../../src/utils/processUtils';
+import { clearCacheForTools } from '../../src/utils/pathUtils';
 import getPort = require('get-port');
 import util = require('util');
 import { affectedByIssue832 } from './testutils';
+import { MockCfg } from '../mocks/MockCfg';
 
 // For debugging test and streaming the trace instead of buffering, set this.
 const DEBUG = process.env['DEBUG'] === '1';
@@ -400,6 +402,39 @@ const testAll = (ctx: Mocha.Context, isDlvDap: boolean, withConsole?: string) =>
 		if (!isDlvDap) {
 			return;
 		}
+		test('should run with dlv provided as a batch file through alternateTools', async function () {
+			if (withConsole || process.platform !== 'win32') {
+				this.skip();
+			}
+
+			clearCacheForTools();
+			const dlvPath = getBinPath('dlv');
+			const wrapperDir = fs.mkdtempSync(path.join(tmpdir(), 'vscode-go-dlv-wrapper '));
+			const wrapperPath = path.join(wrapperDir, 'alternate dlv.bat');
+			fs.writeFileSync(wrapperPath, `@echo off\r\n"${dlvPath}" %*\r\n`);
+
+			const goConfig = new MockCfg({ alternateTools: { dlv: wrapperPath } });
+			const configStub = sinon.stub(extConfig, 'getGoConfig').returns(goConfig);
+
+			try {
+				const program = path.join(DATA_ROOT, 'baseTest');
+				const config = {
+					name: 'Launch',
+					type: 'go',
+					request: 'launch',
+					mode: 'debug',
+					program
+				};
+				const debugConfig = await initializeDebugConfig(config);
+				assert.strictEqual(debugConfig?.dlvToolPath, wrapperPath);
+				await Promise.all([dc.configurationSequence(), dc.launch(debugConfig), dc.waitForEvent('terminated')]);
+			} finally {
+				configStub.restore();
+				clearCacheForTools();
+				tryRmdirRecursive(wrapperDir);
+			}
+		});
+
 		test('should run program to the end', async () => {
 			const PROGRAM = path.join(DATA_ROOT, 'baseTest');
 

--- a/extension/test/integration/goDebug.test.ts
+++ b/extension/test/integration/goDebug.test.ts
@@ -413,7 +413,7 @@ const testAll = (ctx: Mocha.Context, isDlvDap: boolean, withConsole?: string) =>
 			const wrapperPath = path.join(wrapperDir, 'alternate dlv.bat');
 			fs.writeFileSync(wrapperPath, `@echo off\r\n"${dlvPath}" %*\r\n`);
 
-			const goConfig = new MockCfg({ alternateTools: { dlv: wrapperPath } });
+			const goConfig = new MockCfg({ delveConfig: {}, alternateTools: { dlv: wrapperPath } });
 			const configStub = sinon.stub(extConfig, 'getGoConfig').returns(goConfig);
 
 			try {

--- a/extension/test/unit/pathUtils.test.ts
+++ b/extension/test/unit/pathUtils.test.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------
+ * Copyright 2026 The Go Authors. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------*/
+
+import assert from 'assert';
+import { getToolSpawnCommand } from '../../src/utils/pathUtils';
+
+suite('pathUtils tests', () => {
+	test('getToolSpawnCommand', () => {
+		assert.deepStrictEqual(getToolSpawnCommand('C:\\tools with spaces\\dlv.bat', 'win32'), {
+			command: '"C:\\tools with spaces\\dlv.bat"',
+			shell: true
+		});
+		assert.deepStrictEqual(getToolSpawnCommand('C:\\tools\\dlv.CMD', 'win32'), {
+			command: '"C:\\tools\\dlv.CMD"',
+			shell: true
+		});
+		assert.deepStrictEqual(getToolSpawnCommand('C:\\tools\\dlv.exe', 'win32'), {
+			command: 'C:\\tools\\dlv.exe',
+			shell: false
+		});
+		assert.deepStrictEqual(getToolSpawnCommand('/tools/dlv.bat', 'linux'), {
+			command: '/tools/dlv.bat',
+			shell: false
+		});
+	});
+});


### PR DESCRIPTION
Windows cannot launch .bat or .cmd files directly with
child_process.spawn. As a result, a dlv path configured through
go.alternateTools failed before Delve could start.

Detect Windows batch tool paths, quote them, and enable shell execution
for DAP startup, remote-mode probing, and the legacy debug adapter.
Normal executables continue to run directly.

Add unit coverage for spawn command construction and a Windows
integration test that runs Delve through an alternate batch wrapper in
a path containing spaces.

The following checks pass locally:

npm run unit-test
npm run lint
npm run compile
VSCODE_GO_TEST_ALL=true go test ./...
go run tools/generate.go -w=false -gopls=true

The focused integration harness completes successfully on Linux. The
new regression test is Windows-only and will run in the Windows CI job.

Fixes golang/vscode-go#3986